### PR TITLE
Add Solarized

### DIFF
--- a/app/UserPreferences.m
+++ b/app/UserPreferences.m
@@ -166,16 +166,20 @@ static UIColor *UnarchiveColor(id data) {
 
 NSDictionary<NSString *, Theme *> *presetThemes;
 + (void)initialize {
-    presetThemes = @{@"Light": [self _themeWithForegroundColor:UIColor.blackColor
+    presetThemes = @{@"Light":           [self _themeWithForegroundColor:UIColor.blackColor
                                                backgroundColor:UIColor.whiteColor],
-                     @"Dark":  [self _themeWithForegroundColor:UIColor.whiteColor
+                     @"Dark":            [self _themeWithForegroundColor:UIColor.whiteColor
                                                backgroundColor:UIColor.blackColor],
-                     @"1337":  [self _themeWithForegroundColor:UIColor.greenColor
-                                               backgroundColor:UIColor.blackColor]};
+                     @"1337":            [self _themeWithForegroundColor:UIColor.greenColor
+                                               backgroundColor:UIColor.blackColor],
+                     @"Solarized Light": [self _themeWithForegroundColor:[UIColor colorWithRed:88.0/255.0 green:110.0/255.0 blue:117.0/255.0 alpha: 1.0]
+                                               backgroundColor:[UIColor colorWithRed:253.0/255.0 green:246.0/255.0 blue:227.0/255.0 alpha: 1.0]],
+                     @"Solarized Dark":  [self _themeWithForegroundColor:[UIColor colorWithRed:131.0/255.0 green:148.0/255.0 blue:150.0/255.0 alpha: 1.0]
+                                               backgroundColor:[UIColor colorWithRed:0.0 green:43.0/255.0 blue:54.0/255.0 alpha: 1.0]]};
 }
 
 + (NSArray<NSString *> *)presetNames {
-    return @[@"Light", @"Dark", @"1337"];
+    return @[@"Light", @"Dark", @"1337", @"Solarized Light", @"Solarized Dark"];
 }
 + (instancetype)presetThemeNamed:(NSString *)name {
     return presetThemes[name];

--- a/app/UserPreferences.m
+++ b/app/UserPreferences.m
@@ -167,15 +167,15 @@ static UIColor *UnarchiveColor(id data) {
 NSDictionary<NSString *, Theme *> *presetThemes;
 + (void)initialize {
     presetThemes = @{@"Light":           [self _themeWithForegroundColor:UIColor.blackColor
-                                               backgroundColor:UIColor.whiteColor],
+                                                         backgroundColor:UIColor.whiteColor],
                      @"Dark":            [self _themeWithForegroundColor:UIColor.whiteColor
-                                               backgroundColor:UIColor.blackColor],
+                                                         backgroundColor:UIColor.blackColor],
                      @"1337":            [self _themeWithForegroundColor:UIColor.greenColor
-                                               backgroundColor:UIColor.blackColor],
+                                                         backgroundColor:UIColor.blackColor],
                      @"Solarized Light": [self _themeWithForegroundColor:[UIColor colorWithRed:88.0/255.0 green:110.0/255.0 blue:117.0/255.0 alpha: 1.0]
-                                               backgroundColor:[UIColor colorWithRed:253.0/255.0 green:246.0/255.0 blue:227.0/255.0 alpha: 1.0]],
+                                                         backgroundColor:[UIColor colorWithRed:253.0/255.0 green:246.0/255.0 blue:227.0/255.0 alpha: 1.0]],
                      @"Solarized Dark":  [self _themeWithForegroundColor:[UIColor colorWithRed:131.0/255.0 green:148.0/255.0 blue:150.0/255.0 alpha: 1.0]
-                                               backgroundColor:[UIColor colorWithRed:0.0 green:43.0/255.0 blue:54.0/255.0 alpha: 1.0]]};
+                                                         backgroundColor:[UIColor colorWithRed:0.0 green:43.0/255.0 blue:54.0/255.0 alpha: 1.0]]};
 }
 
 + (NSArray<NSString *> *)presetNames {


### PR DESCRIPTION
This adds the Solarized Light and Dark foreground and background colours as themes in `About > Appearance`. It's not the full Solarized palette, only a regular iSH theme.

<details>
  <summary>Show images</summary>

![sol1](https://user-images.githubusercontent.com/17569187/57777209-98a3ab80-7721-11e9-8a86-6aef2366dd54.png)

![sol2](https://user-images.githubusercontent.com/17569187/57777237-b113c600-7721-11e9-8aa1-d166ad80c390.png)
</details>

From recent comment by @apas on issue #14.