### PR TITLE
Xcode Build Phases

### DIFF
--- a/iSH.xcodeproj/project.pbxproj
+++ b/iSH.xcodeproj/project.pbxproj
@@ -792,6 +792,8 @@
 				BB792B4D1F96D90D00FFB7A4 /* Frameworks */,
 				BBF1248B1FA7BF530088FB50 /* Download Alpine */,
 				BBF1248A1FA7BDBA0088FB50 /* Create Alpine Filesystem */,
+				4BD279EB244907F9007556BD /* Modify /etc/motd */,
+				4BD279EC2449080E007556BD /* Modify  /etc/profile */,
 				BB4A53AC1FAA49CA00A72ACE /* Compile JavaScript */,
 				BB792B4E1F96D90D00FFB7A4 /* Resources */,
 				BB88F4A32154760800A341FD /* Embed App Extensions */,
@@ -920,6 +922,42 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		4BD279EB244907F9007556BD /* Modify /etc/motd */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Modify /etc/motd";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cat <<EOF >$SRCROOT/alpine/data/etc/motd\nWelcome to Alpine!\n\nYou can install packages with: apk add <package>\n\nYou may change this message by editing /etc/motd.\n\nEOF\n";
+		};
+		4BD279EC2449080E007556BD /* Modify  /etc/profile */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Modify  /etc/profile";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cat <<EOF >$SRCROOT/alpine/data/etc/profile\n\n#Check for apk and install packages if exists\n\nif hash apk 2>/dev/null; then\n\n    #Install additional packages example\n    #if hash git 2>/dev/null; then\n    #  true #git installed!\n    #else\n    #  apk add --no-cache --wait 60 git\n    #fi\n    true\n\nelse\n  echo apk not installed?\nfi\n\nif hash apk 2>/dev/null; then\n\n  if hash cat /etc/motd 2>/dev/null; then\n  \n  true #Add persistent configuration here\n  \n  else\n  rm -f /etc/motd\n  fi\n\nfi\n\nEOF\n";
+		};
 		BB13F813200AEFAC003D1C4D /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -965,7 +1003,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "rm -rf $SRCROOT/alpine\n$SRCROOT/tools/fakefsify.py $SRCROOT/alpine.tar.gz $SRCROOT/alpine\ncat <<EOF >$SRCROOT/alpine/data/etc/motd\nWelcome to Alpine!\n\nYou can install packages with: apk add <package>\n\nYou may change this message by editing /etc/motd.\n\nEOF\n";
+			shellScript = "rm -rf $SRCROOT/alpine\n$SRCROOT/tools/fakefsify.py $SRCROOT/alpine.tar.gz $SRCROOT/alpine\n";
 			showEnvVarsInLog = 0;
 		};
 		BBF1248B1FA7BF530088FB50 /* Download Alpine */ = {


### PR DESCRIPTION
Change: Create Alpine Filesystem

Add: Modify /etc/motd phase

  1. We isolate this action for clarity

Add: Modify /etc/profile

  1. In this phase we have added an example on how to install the git package
     if not already installed.
     It is commented out to not add over head to CI builds

  2. We remove the /etc/motd file after the initial setup
     This is a way to not redundantly see the motd at every boot.
     We also use the hash cat output to test if /etc/motd not exist
     This provides a block for persistant configs only  after
     the initial boot and setup.