### PR TITLE
Make iOSFS work on iOS 11 and 12 (#700)

### DIFF
--- a/app/iOSFS.m
+++ b/app/iOSFS.m
@@ -58,6 +58,10 @@ const NSFileCoordinatorWritingOptions NSFileCoordinatorWritingForCreating = NSFi
     dispatch_async(dispatch_get_main_queue(), ^(void) {
         UIDocumentPickerViewController *picker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[ @"public.folder" ] inMode:UIDocumentPickerModeOpen];
         picker.delegate = self;
+        if (@available(iOS 13, *)) {
+        } else {
+            picker.allowsMultipleSelection = YES;
+        }
         picker.presentationController.delegate = self;
         [terminalViewController presentViewController:picker animated:true completion:nil];
     });
@@ -74,7 +78,9 @@ const NSFileCoordinatorWritingOptions NSFileCoordinatorWritingForCreating = NSFi
     _urls = nil;
     unlock(&_lock);
     
-    assert(urls.count <= 1);
+    if (@available(iOS 13, *)) {
+        assert(urls.count <= 1);
+    }
     if (urls.count == 0)
         return _ECANCELED;
     *url = urls[0];


### PR DESCRIPTION
I added `picker.allowsMultipleSelection = YES` when it's running on iOS 12 or earlier. This enables the iOSFS to work on iOS 12 or earlier. Besides, behaviors on iOS 13 will not be changed.

If multiple directories are selected, the first one is mounted as you can see on the video below.

![IMB_8zX63v](https://user-images.githubusercontent.com/601636/82730183-e2fa3800-9d38-11ea-84b3-10b3b75f5a33.gif)

Fixes #700