### PR TITLE
Make cursor blink, mitigates #532

### DIFF
--- a/app/terminal/term.js
+++ b/app/terminal/term.js
@@ -131,6 +131,7 @@ exports.updateStyle = ({foregroundColor, backgroundColor, fontFamily, fontSize})
     term.getPrefs().set('background-color', backgroundColor);
     term.getPrefs().set('foreground-color', foregroundColor);
     term.getPrefs().set('cursor-color', foregroundColor);
+    term.getPrefs().set('cursor-blink', true);
     term.getPrefs().set('font-family', fontFamily);
     term.getPrefs().set('font-size', fontSize);
 };


### PR DESCRIPTION
Found no easy way to reverse color the cursor, but blinking makes the text readable. At least with a 50% chance :)