### PR TITLE
Add meson option for declaring SSE2 support.

### DIFF
--- a/emu/cpuid.h
+++ b/emu/cpuid.h
@@ -21,6 +21,7 @@ static inline void do_cpuid(dword_t *eax, dword_t *ebx, dword_t *ecx, dword_t *e
                 | (1 << 15) // cmov
                 | (1 << 23) // mmx
 #ifdef ENABLE_UNSTABLE_SSE
+                // TODO: Remove ifdef guard when SSE2 is stable
                 | (1 << 26) // sse2
 #endif
                 ;

--- a/emu/cpuid.h
+++ b/emu/cpuid.h
@@ -20,6 +20,9 @@ static inline void do_cpuid(dword_t *eax, dword_t *ebx, dword_t *ecx, dword_t *e
             *edx = (1 << 0) // fpu
                 | (1 << 15) // cmov
                 | (1 << 23) // mmx
+#ifdef ENABLE_UNSTABLE_SSE
+                | (1 << 26) // sse2
+#endif
                 ;
             break;
     }

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,10 @@ if get_option('no_crlf')
     add_project_arguments('-DNO_CRLF', language: 'c')
 endif
 
+if get_option('enable_unstable_sse')
+    add_project_arguments('-DENABLE_UNSTABLE_SSE=1', language: 'c')
+endif
+
 add_project_arguments('-Wno-switch', language: 'c')
 
 includes = [include_directories('.')]

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,3 +7,4 @@ option('engine', type: 'combo', choices: ['jit', 'interp'], value: 'jit')
 option('vdso_c_args', type: 'string', value: '')
 
 option('no_crlf', type: 'boolean', value: false)
+option('enable_unstable_sse', type: 'boolean', value: false)


### PR DESCRIPTION
This does not signify that SSE2 is fully supported or supported enough
to run any particular programs. Rather, it is used to signal to programs
running in iSH to behave as if SSE2 is supported so that the programs
can be allowed to crash on the lines where the SSE2 support is lacking.