### PR TITLE
Fix locking issues with CPU refactor

### DIFF
--- a/emu/cpu.h
+++ b/emu/cpu.h
@@ -8,8 +8,7 @@
 
 struct cpu_state;
 struct tlb;
-void cpu_run(struct cpu_state *cpu);
-int cpu_step_to_interrupt(struct cpu_state *cpu, struct tlb *tlb);
+int cpu_run_to_interrupt(struct cpu_state *cpu, struct tlb *tlb);
 
 union mm_reg {
     qword_t qw;

--- a/emu/tlb.c
+++ b/emu/tlb.c
@@ -4,6 +4,7 @@
 void tlb_init(struct tlb *tlb, struct mem *mem) {
     tlb->mem = mem;
     tlb->dirty_page = TLB_PAGE_EMPTY;
+    tlb->mem_changes = mem->changes;
     tlb_flush(tlb);
 }
 

--- a/emu/tlb.h
+++ b/emu/tlb.h
@@ -15,6 +15,7 @@ struct tlb_entry {
 struct tlb {
     struct mem *mem;
     page_t dirty_page;
+    unsigned mem_changes;
     struct tlb_entry entries[TLB_SIZE];
 };
 

--- a/kernel/calls.c
+++ b/kernel/calls.c
@@ -236,7 +236,6 @@ syscall_t syscall_table[] = {
 #define NUM_SYSCALLS (sizeof(syscall_table) / sizeof(syscall_table[0]))
 
 void handle_interrupt(int interrupt) {
-    TRACE_(instr, "\n");
     struct cpu_state *cpu = &current->cpu;
     if (interrupt == INT_SYSCALL) {
         unsigned syscall_num = cpu->eax;

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -162,10 +162,9 @@ struct task *pid_get_task_zombie(dword_t id); // don't return null if the task e
 
 #define MAX_PID (1 << 15) // oughta be enough
 
-// When a thread is created to run a new process, this function is used.
-extern void (*task_run_hook)(void);
 // TODO document
 void task_start(struct task *task);
+void task_run_current();
 
 extern void (*exit_hook)(struct task *task, int code);
 

--- a/main.c
+++ b/main.c
@@ -15,5 +15,5 @@ int main(int argc, char *const argv[]) {
     }
     do_mount(&procfs, "proc", "/proc", "", 0);
     do_mount(&devptsfs, "devpts", "/dev/pts", "", 0);
-    cpu_run(&current->cpu);
+    task_run_current();
 }


### PR DESCRIPTION
There was a deadlock when cpu_run called cpu_step_to_interrupt with mem
read-locked, and it would write-lock mem to clean up jetsam.