### PR TITLE
Fix color of status bar in dark mode

### DIFF
--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -233,6 +233,7 @@
         [self.termView reloadInputViews];
         self.ignoreKeyboardMotion = NO;
     }
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {

--- a/app/UserPreferences.m
+++ b/app/UserPreferences.m
@@ -171,10 +171,14 @@ static UIColor *UnarchiveColor(id data) {
 - (UIStatusBarStyle)statusBarStyle {
     CGFloat lightness;
     [self.backgroundColor getWhite:&lightness alpha:nil];
-    if (lightness > 0.5)
-        return UIStatusBarStyleDefault;
-    else
+    if (lightness > 0.5) {
+        if (@available(iOS 13, *))
+            return UIStatusBarStyleDarkContent;
+        else
+            return UIStatusBarStyleDefault;
+    } else {
         return UIStatusBarStyleLightContent;
+    }
 }
 
 - (UIKeyboardAppearance)keyboardAppearance {


### PR DESCRIPTION
The documentation for UIStatusBarStyleDefault says the result has dark
text, but that's a lie since iOS 13. It is now whatever color goes with
the system appearance. Use UIStatusBarStyleDarkContent instead if we're
on iOS 13 and specifically want dark text.