### PR TITLE
Fix build on Apple Silicon hosts

### DIFF
--- a/xcode-meson.sh
+++ b/xcode-meson.sh
@@ -4,7 +4,7 @@ cd $MESON_BUILD_DIR
 
 config=$(meson introspect --buildoptions)
 if [[ $? -ne 0 ]]; then
-    export CC_FOR_BUILD="env -u SDKROOT -u IPHONEOS_DEPLOYMENT_TARGET clang"
+    export CC_FOR_BUILD="env -u SDKROOT -u IPHONEOS_DEPLOYMENT_TARGET xcrun clang"
     export CC="$CC_FOR_BUILD" # compatibility with meson < 0.54.0
     crossfile=cross.txt
     echo $ARCHS


### PR DESCRIPTION
Invoking clang directly through the Xcode toolchain (which happens because
Xcode sets the PATH) instead of through /usr/bin/clang seems to break SDK
autodetection. Use xcrun to get around this.

Fixes #913