### PR TITLE
Accepted relicense

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -11,6 +11,7 @@ The following authors have agreed to relicense their past contributions under GP
 - Philipp Wallisch <philipp.wallisch@inode.at>
 - Ed Luff <beartechtalks@gmail.com>
 - David Southgate <d@davidsouthgate.co.uk>
+- David <0b101@users.noreply.github.com>
 - [as@irc](https://gist.github.com/tbodt/45ccbea8d3c095258d63f611654f05b4)
 
 [GPLv3]: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
I hereby accept the relicence of [iSH](https://github.com/ish-app/ish) from GPLv3 to GPLv2.

This should be the name and email used for my git contributions. If not, I can change it accordingly. 