### PR TITLE
GPLv2: Christopher Albert

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -18,6 +18,7 @@ The following authors have agreed to relicense their past contributions under GP
 - Matthew Merrill <mattmerr47@gmail.com>
 - Siddharth Dushantha <siddharth.dushantha@gmail.com>
 - Lorenzo De Linares <lorenzo.linares@icloud.com>
+- Christopher Albert <albert@alumni.tugraz.at>
 
 [GPLv3]: https://www.gnu.org/licenses/gpl-3.0.html
 [GPLv2]: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
This is to confirm that I agree with relicensing my contributions to iSH under the GPLv2.