### PR TITLE
Unaligned atomic cmpxchg8b

### DIFF
--- a/jit/gadgets-aarch64/misc.S
+++ b/jit/gadgets-aarch64/misc.S
@@ -121,9 +121,9 @@
     write_bullshit 64, atomic_cmpxchg8b
 
 2: #UNaligned cmpxchg8b (emulated with aligned 16b loads)
-    and x17, _xaddr, 7
+    and x17, _xaddr, 0xF
     lsl x17, x17, 3
-    and _xaddr, _xaddr, -7
+    and _xaddr, _xaddr, -15
     
     write_prep 128, atomic_cmpxchg8b_unaligned
     mov w10, eax

--- a/jit/gadgets-aarch64/misc.S
+++ b/jit/gadgets-aarch64/misc.S
@@ -207,8 +207,9 @@
     bfi x11, xcx, 32, 32
 
 5:
-    ldaxr x8, [_xaddr]
-    ldar x9, [_xaddr, #8]
+    ldar x8, [_xaddr]
+    add _xaddr, _xaddr, 8
+    ldar x9, [_xaddr]
     
     lsl x12, x8, x17
     neg x13, x17
@@ -237,9 +238,9 @@
     lsl x12, x12, x17
     orr x9, x9, x12
     
-    stlr x9, [_xaddr, #8]
-    stlxr w14, x8, [_xaddr]
-    cbnz x14, 5b
+    stlr x9, [_xaddr]
+    sub _xaddr, _xaddr, 8
+    stlr x8, [_xaddr]
     
     write_done 128, atomic_cmpxchg8b_unpaired
     ubfx xax, x10, 0, 32
@@ -253,7 +254,7 @@
     str w9, [_cpu, CPU_eflags]
     
     gret 1
-    write_bullshit 128, atomic_cmpxchg8b_brokenpair
+    write_bullshit 128, atomic_cmpxchg8b_unpaired
     
 .gadget cmpxchg8b
     write_prep 64, cmpxchg8b

--- a/jit/gadgets-aarch64/misc.S
+++ b/jit/gadgets-aarch64/misc.S
@@ -92,7 +92,8 @@
     tst _addr, 7
     b.ne 2f
     
-    #Aligned cmpxchg8b
+    #cmpxchg8b via aligned exclusive 8b load
+
     write_prep 64, atomic_cmpxchg8b
     mov w9, eax
     bfi x9, xdx, 32, 32
@@ -120,12 +121,21 @@
     gret 1
     write_bullshit 64, atomic_cmpxchg8b
 
-2: #UNaligned cmpxchg8b (emulated with aligned 16b loads)
-    and x17, _xaddr, 0xF
+2:  #UNaligned cmpxchg8b
+    tst _addr, 8
+    b.ne 4f
+    
+    #cmpxchg8b via shifted exclusive 16b load
+
+    #This preserves (some) atomicity but requires the address to be no more
+    #than 8 bytes misaligned.
+
+    and x17, _xaddr, 7
     lsl x17, x17, 3
     and _xaddr, _xaddr, -15
-    
-    write_prep 128, atomic_cmpxchg8b_unaligned
+
+    write_prep 128, atomic_cmpxchg8b_shifted
+
     mov w10, eax
     bfi x10, xdx, 32, 32
     mov w11, ebx
@@ -164,7 +174,7 @@
     stlxp w14, x8, x9, [_xaddr]
     cbnz x14, 3b
     
-    write_done 128, atomic_cmpxchg8b_unaligned
+    write_done 128, atomic_cmpxchg8b_shifted
     ubfx xax, x10, 0, 32
     ubfx xdx, x10, 32, 32
 
@@ -174,11 +184,76 @@
     bfi w9, w11, 6, 1
     str w8, [_cpu, CPU_flags_res]
     str w9, [_cpu, CPU_eflags]
-
-    orr _xaddr, _xaddr, x17
     
     gret 1
-    write_bullshit 128, atomic_cmpxchg8b_unaligned
+    write_bullshit 128, atomic_cmpxchg8b_shifted
+
+4:  #cmpxchg8b via multiple shifted non-exclusive 8b loads
+
+    #This can handle any amount of misalignment but at the cost of atomicity.
+    #This matches with Intel's documentation, at least: unaligned memory
+    #accesses that fit within one cache line are be atomic, but those that
+    #aren't lose atomicity guarantees.
+
+    and x17, _xaddr, 7
+    lsl x17, x17, 3
+    and _xaddr, _xaddr, -7
+
+    write_prep 128, atomic_cmpxchg8b_unpaired
+
+    mov w10, eax
+    bfi x10, xdx, 32, 32
+    mov w11, ebx
+    bfi x11, xcx, 32, 32
+
+5:
+    ldaxr x8, [_xaddr]
+    ldar x9, [_xaddr, #8]
+    
+    lsl x12, x8, x17
+    neg x13, x17
+    add x13, x13, 64
+    lsr x13, x9, x13
+    orr x12, x12, x13
+
+    cmp x10, x12
+    csel x10, x12, x10, ne
+    csel x12, x11, x12, eq
+    cset w13, eq
+    
+    mov x14, -1
+    neg x15, x17
+    add x15, x15, 64
+    lsr x14, x14, x15
+    mvn x14, x14
+    and x8, x8, x14
+    lsr x14, x12, x15
+    orr x8, x8, x14
+
+    mov x14, -1
+    lsl x14, x14, x17
+    mvn x14, x14
+    and x9, x9, x14
+    lsl x12, x12, x17
+    orr x9, x9, x12
+    
+    stlr x9, [_xaddr, #8]
+    stlxr w14, x8, [_xaddr]
+    cbnz x14, 5b
+    
+    write_done 128, atomic_cmpxchg8b_unpaired
+    ubfx xax, x10, 0, 32
+    ubfx xdx, x10, 32, 32
+
+    ldr w8, [_cpu, CPU_flags_res]
+    ldr w9, [_cpu, CPU_eflags]
+    and w8, w8, ~ZF_RES
+    bfi w9, w11, 6, 1
+    str w8, [_cpu, CPU_flags_res]
+    str w9, [_cpu, CPU_eflags]
+    
+    gret 1
+    write_bullshit 128, atomic_cmpxchg8b_brokenpair
     
 .gadget cmpxchg8b
     write_prep 64, cmpxchg8b

--- a/jit/gadgets-aarch64/misc.S
+++ b/jit/gadgets-aarch64/misc.S
@@ -90,7 +90,7 @@
 .gadget atomic_cmpxchg8b
     #Test for alignment.
     tst _addr, 7
-    b.ne 2b
+    b.ne 2f
     
     #Aligned cmpxchg8b
     write_prep 64, atomic_cmpxchg8b

--- a/jit/gadgets-aarch64/misc.S
+++ b/jit/gadgets-aarch64/misc.S
@@ -88,6 +88,11 @@
 .gadget_array atomic_cmpxchg
 
 .gadget atomic_cmpxchg8b
+    #Test for alignment.
+    tst _addr, 0xF
+    b.ne 2b
+    
+    #Aligned cmpxchg8b
     write_prep 64, atomic_cmpxchg8b
     mov w9, eax
     bfi x9, xdx, 32, 32
@@ -115,6 +120,64 @@
     gret 1
     write_bullshit 64, atomic_cmpxchg8b
 
+2: #UNaligned cmpxchg8b (emulated with aligned 16b loads)
+    and x17, _xaddr, 7
+    lsl x17, x17, 3
+    and _xaddr, _xaddr, -7
+    
+    write_prep 128, atomic_cmpxchg8b_unaligned
+    mov w10, eax
+    bfi x10, xdx, 32, 32
+    mov w11, ebx
+    bfi x11, xcx, 32, 32
+
+3:
+    ldaxp x8, x9, [_xaddr]
+    
+    lsl x12, x8, x17
+    neg x13, x17
+    add x13, x13, 64
+    lsr x13, x9, x13
+    orr x12, x12, x13
+
+    cmp x10, x12
+    csel x10, x12, x10, ne
+    csel x12, x11, x12, eq
+    cset w13, eq
+    
+    mov x14, -1
+    neg x15, x17
+    add x15, x15, 64
+    lsr x14, x14, x15
+    mvn x14, x14
+    and x8, x8, x14
+    lsr x14, x12, x15
+    orr x8, x8, x14
+
+    mov x14, -1
+    lsl x14, x14, x17
+    mvn x14, x14
+    and x9, x9, x14
+    lsl x12, x12, x17
+    orr x9, x9, x12
+    
+    stlxp w14, x8, x9, [_xaddr]
+    cbnz x14, 3b
+    
+    write_done 128, atomic_cmpxchg8b_unaligned
+    ubfx xax, x10, 0, 32
+    ubfx xdx, x10, 32, 32
+
+    ldr w8, [_cpu, CPU_flags_res]
+    ldr w9, [_cpu, CPU_eflags]
+    and w8, w8, ~ZF_RES
+    bfi w9, w11, 6, 1
+    str w8, [_cpu, CPU_flags_res]
+    str w9, [_cpu, CPU_eflags]
+    
+    gret 1
+    write_bullshit 128, atomic_cmpxchg8b_unaligned
+    
 .gadget cmpxchg8b
     write_prep 64, cmpxchg8b
     mov w9, eax

--- a/jit/gadgets-aarch64/misc.S
+++ b/jit/gadgets-aarch64/misc.S
@@ -89,7 +89,7 @@
 
 .gadget atomic_cmpxchg8b
     #Test for alignment.
-    tst _addr, 0xF
+    tst _addr, 7
     b.ne 2b
     
     #Aligned cmpxchg8b
@@ -174,6 +174,8 @@
     bfi w9, w11, 6, 1
     str w8, [_cpu, CPU_flags_res]
     str w9, [_cpu, CPU_eflags]
+
+    orr _xaddr, _xaddr, x17
     
     gret 1
     write_bullshit 128, atomic_cmpxchg8b_unaligned


### PR DESCRIPTION
This PR adds an unaligned mode to our implementation of `lock cmpxchg8b` that uses AArch64's `ldaxp` instruction to do 128-bit *aligned* loads and then manually align the loaded bits with shifts.

This isn't perfect; we make no attempt to check if we are off the end of the unaligned load. Technically speaking, we cannot guarantee atomicity for cross-cache-line loads... but then again, neither did Intel. Badly misaligned loads get broken into two nonatomic loads, which matches all of the references I can find about x86.

This PR fixes MySQL crashing the emulator. It now throws up an error about Linux Direct AIO being unimplemented.