### PR TITLE
Use python3 during build

### DIFF
--- a/tools/staticdefine.sh
+++ b/tools/staticdefine.sh
@@ -3,7 +3,7 @@ compile_commands=$1
 input=$2
 output=$3
 dep=$4
-flags=$(python - <<END
+flags=$(python3 - <<END
 import json
 with open('$compile_commands') as f:
     commands = json.load(f)


### PR DESCRIPTION
fixes #1460, now builds and runs fine on ubuntu 20.04 (which doesn't ship with python2)