### PR TITLE
Docs: Fix readme cli quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can replace `ish` with `tools/ptraceomatic` to run the program in a real pro
 iSH has several logging channels which can be enabled at build time. By default, all of them are disabled. To enable them:
 
 - In Xcode: Set the `ISH_LOG` setting in iSH.xcconfig to a space-separated list of log channels.
-- With Meson (command line tool for testing): Run `meson configure -Dlog="<space-separated list of log channels>`.
+- With Meson (command line tool for testing): Run `meson configure -Dlog="<space-separated list of log channels>"`.
 
 Available channels:
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -52,7 +52,7 @@ Xcode로 프로젝트를 열고, iSH.xcconfig 연 후에 `ROOT_BUNDLE_IDENTIFIER
 iSH 는 빌드 시간에 허용될 수 있는 다수의 로깅 채널을 갖고 있습니다. 기본 값으로는 모두 꺼놨는데, 사용을 위해서는:
 
 - Xcode에서: iSH.xcconfig에 있는 `ISH_LOG` 값을 스페이스로 나뉜 로그 채널 리스트로 설정해주세요.
-- Meson에서 (테스트를 위한 커맨드 라인 도구): `meson configure -Dlog="<스페이스로 나뉜 로그 채널 리스트>`을 실행하세요.
+- Meson에서 (테스트를 위한 커맨드 라인 도구): `meson configure -Dlog="<스페이스로 나뉜 로그 채널 리스트>"`을 실행하세요.
 
 제공되는 로그 채널:
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -49,7 +49,7 @@ iSH 是一个运行在 iOS 上的 Linux shell。本项目使用了 x86 用户模
 在编译过程中，iSH 提供数种日志类型，默认情况下它们都被禁用，想要启用它们需要:
 
 - 在 Xcode 中将 iSH.xcconfig 中 `ISH_LOG` 设置为以空格分隔的日志类型列表。
-- 在 Meson (测试使用的命令行工具) 中执行命令 `meson configure -Dlog="<space-separated list of log channels>`。
+- 在 Meson (测试使用的命令行工具) 中执行命令 `meson configure -Dlog="<space-separated list of log channels>"`。
 
 可用的日志类型:
 


### PR DESCRIPTION
This is probably the intended example line. Not sure if the quote when copied&pasted may fail, just proposing this fixup to be safe.