### PR TITLE
Remove DEVELOPMENT_TEAM from xcode project

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You'll need these things to build the project:
 
 ## Build for iOS
 
-Open the project in Xcode, open iSH.xcconfig, and change `ROOT_BUNDLE_IDENTIFIER` to something unique. Then click Run. There are scripts that should do everything else automatically. If you run into any problems, open an issue and I'll try to help.
+Open the project in Xcode, open iSH.xcconfig, and change `ROOT_BUNDLE_IDENTIFIER` to something unique. You'll also need to update the development team ID in the project (not target!) build settings. Then click Run. There are scripts that should do everything else automatically. If you run into any problems, open an issue and I'll try to help.
 
 ## Build command line tool for testing
 

--- a/app/iSH.xcconfig
+++ b/app/iSH.xcconfig
@@ -1,5 +1,7 @@
 // Change this to change all the bundle IDs and app groups
 ROOT_BUNDLE_IDENTIFIER = app.ish.iSH
+// It's easiest to specify your development team ID in the project build settings, but you can alternatively put it here to reduce merge conflicts
+DEVELOPMENT_TEAM =
 
 // Choose logging channels to enable. Separate by spaces. Try "verbose strace".
 ISH_LOG =

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,6 +29,7 @@ lane :build do |options|
       project: "iSH.xcodeproj",
       scheme: "iSH",
       xcconfig: config,
+      xcargs: "DEVELOPMENT_TEAM=#{CredentialsManager::AppfileConfig.try_fetch_value(:team_id)}",
       output_name: options[:output],
     )
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -28,6 +28,6 @@ fastlane upload_build
 
 ----
 
-This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
 The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/iSH.xcodeproj/project.pbxproj
+++ b/iSH.xcodeproj/project.pbxproj
@@ -1496,43 +1496,35 @@
 				TargetAttributes = {
 					497F6CE3254E5E4C00C82F46 = {
 						CreatedOnToolsVersion = 12.2;
-						DevelopmentTeam = CK5SXRTBR7;
 					};
 					497F6D46254E605F00C82F46 = {
 						CreatedOnToolsVersion = 12.2;
-						DevelopmentTeam = CK5SXRTBR7;
 						ProvisioningStyle = Automatic;
 					};
 					BB13F7CA200ACC31003D1C4D = {
 						CreatedOnToolsVersion = 9.2;
-						DevelopmentTeam = CK5SXRTBR7;
 						ProvisioningStyle = Automatic;
 					};
 					BB13F7D0200ACCA2003D1C4D = {
 						CreatedOnToolsVersion = 9.2;
-						DevelopmentTeam = CK5SXRTBR7;
 						ProvisioningStyle = Automatic;
 					};
 					BB13F7DB200AD81D003D1C4D = {
 						CreatedOnToolsVersion = 9.2;
-						DevelopmentTeam = CK5SXRTBR7;
 						ProvisioningStyle = Automatic;
 					};
 					BB41591B255EF9E300E0950C = {
 						CreatedOnToolsVersion = 12.2;
-						DevelopmentTeam = CK5SXRTBR7;
 						LastSwiftMigration = 1220;
 						ProvisioningStyle = Automatic;
 						TestTargetID = BB792B4F1F96D90D00FFB7A4;
 					};
 					BB4A922324ED9402002F5A96 = {
 						CreatedOnToolsVersion = 11.5;
-						DevelopmentTeam = CK5SXRTBR7;
 						ProvisioningStyle = Automatic;
 					};
 					BB792B4F1F96D90D00FFB7A4 = {
 						CreatedOnToolsVersion = 9.0;
-						DevelopmentTeam = CK5SXRTBR7;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
@@ -1542,7 +1534,6 @@
 					};
 					BB88F48F2154760800A341FD = {
 						CreatedOnToolsVersion = 10.0;
-						DevelopmentTeam = CK5SXRTBR7;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
@@ -2315,7 +2306,6 @@
 			baseConfigurationReference = BB0B85A42586F1CB00208600 /* ProjectDebug.xcconfig */;
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 279;
-				DEVELOPMENT_TEAM = CK5SXRTBR7;
 			};
 			name = "Debug-ApplePleaseFixFB19282108";
 		};
@@ -2324,7 +2314,6 @@
 			baseConfigurationReference = BB0B85A52586F1E100208600 /* ProjectRelease.xcconfig */;
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 279;
-				DEVELOPMENT_TEAM = CK5SXRTBR7;
 			};
 			name = Release;
 		};
@@ -2347,7 +2336,6 @@
 			baseConfigurationReference = BB28C7532689522C00BDC834 /* ProjectDebugLinux.xcconfig */;
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 279;
-				DEVELOPMENT_TEAM = CK5SXRTBR7;
 			};
 			name = DebugLinux;
 		};
@@ -2565,7 +2553,6 @@
 			baseConfigurationReference = BB28C7522689522700BDC834 /* ProjectReleaseLinux.xcconfig */;
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 279;
-				DEVELOPMENT_TEAM = CK5SXRTBR7;
 			};
 			name = ReleaseLinux;
 		};


### PR DESCRIPTION
Specifying it here guarantees that the CURRENT_PROJECT_VERSION updates will merge conflict.