### PR TITLE
Specify a module for UIApplicationMain breakpoint

### DIFF
--- a/iSH.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/iSH.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -12,7 +12,7 @@
             ignoreCount = "0"
             continueAfterRunningActions = "Yes"
             symbolName = "UIApplicationMain"
-            moduleName = "">
+            moduleName = "UIKitCore">
             <Actions>
                <BreakpointActionProxy
                   ActionExtensionID = "Xcode.BreakpointAction.DebuggerCommand">


### PR DESCRIPTION
This prevents Xcode from detecting UIApplicationMain in libswiftUIKit.dylib.