### PR TITLE
Segfault the guest process when we encounter an unaligned atomic cmpxchg8b

### DIFF
--- a/jit/gadgets-aarch64/memory.S
+++ b/jit/gadgets-aarch64/memory.S
@@ -83,6 +83,7 @@ NAME(si_gadgets):
         mov _xaddr, x19
         ret
 
+.global segfault_\type
 segfault_\type:
     ldr _addr, [_tlb, -TLB_entries+TLB_segfault_addr]
     str _addr, [_cpu, CPU_segfault_addr]

--- a/jit/gadgets-aarch64/misc.S
+++ b/jit/gadgets-aarch64/misc.S
@@ -87,7 +87,14 @@
 .gadget_array cmpxchg
 .gadget_array atomic_cmpxchg
 
+.extern segfault_write
+
 .gadget atomic_cmpxchg8b
+    #Test for alignment.
+    tst _addr, 0x7
+    b.ne 2f
+
+    #cmpxchg8b via aligned exclusive 8b load
     write_prep 64, atomic_cmpxchg8b
     mov w9, eax
     bfi x9, xdx, 32, 32
@@ -114,6 +121,10 @@
     str w9, [_cpu, CPU_eflags]
     gret 1
     write_bullshit 64, atomic_cmpxchg8b
+
+2:  #All unaligned paths
+    b segfault_write
+
 
 .gadget cmpxchg8b
     write_prep 64, cmpxchg8b


### PR DESCRIPTION
Like #1429, but less wrong.

My prior PR misinterpreted certain paragraphs of Intel's processor documentation. Unaligned `lock cmpxchg8b` maintains atomicity *regardless* of alignment; this is not emulatable with ARM atomics alone. Properly emulating this requires a complicated locking setup that would almost certainly harm the performance of well-behaved x86 processes. In fact, I'm pretty sure the prior PR *never worked* - I've noticed this crash doesn't always occur when you launch `mariadbd`; and it's entirely possible that I was just getting very lucky with heap allocations that just so happened to align whatever packed structs are there.

So, instead, here's a new PR that triggers a segfault on unaligned atomic access. This will keep the user from losing any other work they might have been doing in other guest processes.