### PR TITLE
Print the process name as well as the pid on 'stub syscall'

### DIFF
--- a/kernel/calls.c
+++ b/kernel/calls.c
@@ -249,11 +249,11 @@ void handle_interrupt(int interrupt) {
     if (interrupt == INT_SYSCALL) {
         unsigned syscall_num = cpu->eax;
         if (syscall_num >= NUM_SYSCALLS || syscall_table[syscall_num] == NULL) {
-            printk("%d missing syscall %d\n", current->pid, syscall_num);
+            printk("%d(%s) missing syscall %d\n", current->pid, current->comm, syscall_num);
             deliver_signal(current, SIGSYS_, SIGINFO_NIL);
         } else {
             if (syscall_table[syscall_num] == (syscall_t) syscall_stub) {
-                printk("%d stub syscall %d\n", current->pid, syscall_num);
+                printk("%d(%s) stub syscall %d\n", current->pid, current->comm, syscall_num);
             }
             STRACE("%d call %-3d ", current->pid, syscall_num);
             int result = syscall_table[syscall_num](cpu->ebx, cpu->ecx, cpu->edx, cpu->esi, cpu->edi, cpu->ebp);


### PR DESCRIPTION
MacBook-Pro:~# dmesg | uniq
8(login) stub syscall 383
10(ash) stub syscall 383
11(ash) stub syscall 383
9(ash) stub syscall 383
15(ls) stub syscall 383
9(ash) stub syscall 383
17(sshd) stub syscall 383
19(sshd) stub syscall 364
20(sshd) stub syscall 383
22(sshd) stub syscall 383
23(ash) stub syscall 383
24(ash) stub syscall 383
22(ash) stub syscall 383
27(apk) stub syscall 383
28(busybox-1.33.1-r) stub syscall 383
22(ash) stub syscall 383
