### PR TITLE
Enhancements to /proc/meminfo

### DIFF
--- a/fs/proc/root.c
+++ b/fs/proc/root.c
@@ -26,11 +26,15 @@ static int proc_show_meminfo(struct proc_entry *UNUSED(entry), struct proc_data 
     struct mem_usage usage = get_mem_usage();
     show_kb(buf, "MemTotal:       ", usage.total);
     show_kb(buf, "MemFree:        ", usage.free);
+    show_kb(buf, "MemAvailable:   ", usage.available);
     show_kb(buf, "MemShared:      ", usage.free);
+    show_kb(buf, "Active:         ", usage.active);
+    show_kb(buf, "Inactive:       ", usage.inactive);
+    show_kb(buf, "SwapCached:     ", 0);
     // a bunch of crap busybox top needs to see or else it gets stack garbage
     show_kb(buf, "Shmem:          ", 0);
     show_kb(buf, "Buffers:        ", 0);
-    show_kb(buf, "Cached:         ", 0);
+    show_kb(buf, "Cached:         ", usage.cached);
     show_kb(buf, "SwapTotal:      ", 0);
     show_kb(buf, "SwapFree:       ", 0);
     show_kb(buf, "Dirty:          ", 0);
@@ -38,6 +42,10 @@ static int proc_show_meminfo(struct proc_entry *UNUSED(entry), struct proc_data 
     show_kb(buf, "AnonPages:      ", 0);
     show_kb(buf, "Mapped:         ", 0);
     show_kb(buf, "Slab:           ", 0);
+    // Stuff that doesn't map elsehwere
+    show_kb(buf, "Swapins:        ", usage.swapins);
+    show_kb(buf, "Swapouts:       ", usage.swapouts);
+    show_kb(buf, "WireCount:      ", usage.wirecount);
     return 0;
 }
 

--- a/platform/darwin.c
+++ b/platform/darwin.c
@@ -26,8 +26,13 @@ struct mem_usage get_mem_usage() {
     struct mem_usage usage;
     usage.total = basic.max_mem;
     usage.free = vm.free_count * vm_page_size;
+    usage.available = basic.memory_size;
+    usage.cached = vm.speculative_count * vm_page_size;
     usage.active = vm.active_count * vm_page_size;
     usage.inactive = vm.inactive_count * vm_page_size;
+    usage.wirecount = vm.wire_count * vm_page_size;
+    usage.swapins = vm.swapins * vm_page_size;
+    usage.swapouts = vm.swapouts * vm_page_size;
     return usage;
 }
 

--- a/platform/platform.h
+++ b/platform/platform.h
@@ -14,8 +14,13 @@ struct cpu_usage get_cpu_usage(void);
 struct mem_usage {
     uint64_t total;
     uint64_t free;
+    uint64_t available;
+    uint64_t cached;
     uint64_t active;
     uint64_t inactive;
+    uint64_t swapins;
+    uint64_t swapouts;
+    uint64_t wirecount;
 };
 struct mem_usage get_mem_usage(void);
 


### PR DESCRIPTION
```(09:59 ish /~)-> cat /proc/meminfo 
MemTotal:       68719476 kB
MemFree:         1210925 kB
MemAvailable:    3060908 kB
MemShared:       1210925 kB
Active:         20130316 kB
Inactive:       20031979 kB
SwapCached:            0 kB
Shmem:                 0 kB
Buffers:               0 kB
Cached:           104742 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Dirty:                 0 kB
Writeback:             0 kB
AnonPages:             0 kB
Mapped:                0 kB
Slab:                  0 kB
Swapins:               0 kB
Swapouts:              0 kB
WireCount:       4128555 kB
```