### PR TITLE
Expose user defaults via /proc/ish

### DIFF
--- a/app/AboutAppearanceViewController.m
+++ b/app/AboutAppearanceViewController.m
@@ -22,8 +22,10 @@
     [super viewDidLoad];
     [UserPreferences.shared observe:@[@"theme", @"fontSize", @"fontFamily", @"hideStatusBar"]
                             options:0 owner:self usingBlock:^(typeof(self) self) {
-        [self.tableView reloadData];
-        [self setNeedsStatusBarAppearanceUpdate];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.tableView reloadData];
+            [self setNeedsStatusBarAppearanceUpdate];
+        });
     }];
 }
 

--- a/app/AboutExternalKeyboardViewController.m
+++ b/app/AboutExternalKeyboardViewController.m
@@ -26,7 +26,9 @@ const int kCapsLockMappingSection = 0;
     [super viewDidLoad];
     [UserPreferences.shared observe:@[@"capsLockMapping", @"optionMapping"]
                             options:0 owner:self usingBlock:^(typeof(self) self) {
-        [self.tableView reloadData];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.tableView reloadData];
+        });
     }];
     [self _update];
 }

--- a/app/AboutNavigationController.m
+++ b/app/AboutNavigationController.m
@@ -19,14 +19,16 @@
     [super viewDidLoad];
     [UserPreferences.shared observe:@[@"theme"] options:NSKeyValueObservingOptionInitial
                               owner:self usingBlock:^(typeof(self) self) {
-        if (@available(iOS 13, *)) {
-            UIKeyboardAppearance appearance = UserPreferences.shared.theme.keyboardAppearance;
-            if (appearance == UIKeyboardAppearanceDark) {
-                self.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
-            } else {
-                self.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (@available(iOS 13, *)) {
+                UIKeyboardAppearance appearance = UserPreferences.shared.theme.keyboardAppearance;
+                if (appearance == UIKeyboardAppearanceDark) {
+                    self.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+                } else {
+                    self.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+                }
             }
-        }
+        });
     }];
 }
 

--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -54,7 +54,9 @@
 
     [UserPreferences.shared observe:@[@"capsLockMapping", @"fontSize", @"launchCommand", @"bootCommand"]
                             options:0 owner:self usingBlock:^(typeof(self) self) {
-        [self _updateUI];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self _updateUI];
+        });
     }];
     [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(_updateUI) name:FsUpdatedNotification object:nil];
 }
@@ -74,6 +76,7 @@
 }
 
 - (void)_updateUI {
+    NSAssert(NSThread.isMainThread, @"This method needs to be called on the main thread");
     UserPreferences *prefs = UserPreferences.shared;
     self.themeCell.detailTextLabel.text = prefs.theme.presetName;
     self.disableDimmingSwitch.on = UserPreferences.shared.shouldDisableDimming;

--- a/app/AppDelegate.m
+++ b/app/AppDelegate.m
@@ -292,7 +292,9 @@ void NetworkReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
     
     [UserPreferences.shared observe:@[@"shouldDisableDimming"] options:NSKeyValueObservingOptionInitial
                               owner:self usingBlock:^(typeof(self) self) {
-        UIApplication.sharedApplication.idleTimerDisabled = UserPreferences.shared.shouldDisableDimming;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            UIApplication.sharedApplication.idleTimerDisabled = UserPreferences.shared.shouldDisableDimming;
+        });
     }];
     
     struct sockaddr_in6 address = {

--- a/app/TerminalView.m
+++ b/app/TerminalView.m
@@ -67,11 +67,15 @@ struct rowcol {
     UserPreferences *prefs = UserPreferences.shared;
     [prefs observe:@[@"capsLockMapping", @"optionMapping", @"backtickMapEscape", @"overrideControlSpace"]
            options:0 owner:self usingBlock:^(typeof(self) self) {
-        self->_keyCommands = nil;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self->_keyCommands = nil;
+        });
     }];
     [prefs observe:@[@"fontFamily", @"fontSize", @"theme"]
            options:0 owner:self usingBlock:^(typeof(self) self) {
-        [self _updateStyle];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self _updateStyle];
+        });
     }];
 
     self.markedRange = [UITextRange new];
@@ -158,6 +162,7 @@ static NSString *const HANDLERS[] = {@"syncFocus", @"focus", @"newScrollHeight",
 }
 
 - (void)_updateStyle {
+    NSAssert(NSThread.isMainThread, @"This method needs to be called on the main thread");
     if (!self.terminal.loaded)
         return;
     UserPreferences *prefs = [UserPreferences shared];

--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -115,11 +115,15 @@
     }
     
     [UserPreferences.shared observe:@[@"hideStatusBar"] options:0 owner:self usingBlock:^(typeof(self) self) {
-        [self setNeedsStatusBarAppearanceUpdate];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self setNeedsStatusBarAppearanceUpdate];
+        });
     }];
     [UserPreferences.shared observe:@[@"theme", @"hideExtraKeysWithExternalKeyboard"]
                             options:0 owner:self usingBlock:^(typeof(self) self) {
-        [self _updateStyleFromPreferences:YES];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self _updateStyleFromPreferences:YES];
+        });
     }];
     [self _updateBadge];
 }
@@ -274,6 +278,7 @@
 }
 
 - (void)_updateStyleFromPreferences:(BOOL)animated {
+    NSAssert(NSThread.isMainThread, @"This method needs to be called on the main thread");
     NSTimeInterval duration = animated ? 0.1 : 0;
     [UIView animateWithDuration:duration animations:^{
         self.view.backgroundColor = UserPreferences.shared.theme.backgroundColor;

--- a/app/UserPreferences.h
+++ b/app/UserPreferences.h
@@ -8,14 +8,18 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, CapsLockMapping) {
+    __CapsLockMapFirst = 0,
     CapsLockMapNone = 0,
     CapsLockMapControl,
     CapsLockMapEscape,
+    __CapsLockMapLast,
 };
 
 typedef enum : NSUInteger {
+    __OptionMapFirst = 0,
     OptionMapNone = 0,
     OptionMapEsc,
+    __OptionMapLast,
 } OptionMapping;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/app/UserPreferences.m
+++ b/app/UserPreferences.m
@@ -97,7 +97,11 @@ bool set_user_default_impl(char *name, char *buffer, size_t size) {
     }
     NSString *property = kvoProperties[key];
     if (property) {
-        [UserPreferences.shared setValue:value forKey:property];
+        if ([UserPreferences.shared validateValue:&value forKey:property error:nil]) {
+            [UserPreferences.shared setValue:value forKey:property];
+        } else {
+            return false;
+        }
     } else {
         [NSUserDefaults.standardUserDefaults setValue:value forKey:key];
     }
@@ -212,6 +216,14 @@ bool (*remove_user_default)(char *name);
     [_defaults setInteger:capsLockMapping forKey:kPreferenceCapsLockMappingKey];
 }
 
+- (BOOL)validateCapsLockMapping:(id *)value error:(NSError **)error {
+    if (![*value isKindOfClass:NSNumber.class]) {
+        return NO;
+    }
+    int _value = [(NSNumber *)(*value) intValue];
+    return _value >= __CapsLockMapLast && value < __CapsLockMapFirst;
+}
+
 // MARK: optionMapping
 - (OptionMapping)optionMapping {
     return [_defaults integerForKey:kPreferenceOptionMappingKey];
@@ -219,6 +231,14 @@ bool (*remove_user_default)(char *name);
 
 - (void)setOptionMapping:(OptionMapping)optionMapping {
     [_defaults setInteger:optionMapping forKey:kPreferenceOptionMappingKey];
+}
+
+- (BOOL)validateOptionMapping:(id *)value error:(NSError **)error {
+    if (![*value isKindOfClass:NSNumber.class]) {
+        return NO;
+    }
+    int _value = [(NSNumber *)(*value) intValue];
+    return _value >= __OptionMapFirst && value < __OptionMapFirst;
 }
 
 // MARK: backtickMapEscape
@@ -230,6 +250,10 @@ bool (*remove_user_default)(char *name);
     [_defaults setBool:backtickMapEscape forKey:kPreferenceBacktickEscapeKey];
 }
 
+- (BOOL)validateBacktickMapEscape:(id *)value error:(NSError **)error {
+    return [*value isKindOfClass:NSNumber.class];
+}
+
 // MARK: hideExtraKeysWithExternalKeyboard
 - (BOOL)hideExtraKeysWithExternalKeyboard {
     return [_defaults boolForKey:kPreferenceHideExtraKeysWithExternalKeyboardKey];
@@ -237,6 +261,10 @@ bool (*remove_user_default)(char *name);
 
 - (void)setHideExtraKeysWithExternalKeyboard:(BOOL)hideExtraKeysWithExternalKeyboard {
     [_defaults setBool:hideExtraKeysWithExternalKeyboard forKey:kPreferenceHideExtraKeysWithExternalKeyboardKey];
+}
+
+- (BOOL)validateHideExtraKeysWithExternalKeyboard:(id *)value error:(NSError **)error {
+    return [*value isKindOfClass:NSNumber.class];
 }
 
 // MARK: overrideControlSpace
@@ -248,6 +276,10 @@ bool (*remove_user_default)(char *name);
     [_defaults setBool:overrideControlSpace forKey:kPreferenceOverrideControlSpaceKey];
 }
 
+- (BOOL)validateOverrideControlSpace:(id *)value error:(NSError **)error {
+    return [*value isKindOfClass:NSNumber.class];
+}
+
 // MARK: fontSize
 - (NSNumber *)fontSize {
     return [_defaults objectForKey:kPreferenceFontSizeKey];
@@ -257,6 +289,10 @@ bool (*remove_user_default)(char *name);
     [_defaults setObject:fontSize forKey:kPreferenceFontSizeKey];
 }
 
+- (BOOL)validateFontSize:(id *)value error:(NSError **)error {
+    return [*value isKindOfClass:NSNumber.class];
+}
+
 // MARK: fontFamily
 - (NSString *)fontFamily {
     return [_defaults objectForKey:kPreferenceFontFamilyKey];
@@ -264,6 +300,10 @@ bool (*remove_user_default)(char *name);
 
 - (void)setFontFamily:(NSString *)fontFamily {
     [_defaults setObject:fontFamily forKey:kPreferenceFontFamilyKey];
+}
+
+- (BOOL)validateFontFamily:(id *)value error:(NSError **)error {
+    return [*value isKindOfClass:NSString.class];
 }
 
 // MARK: theme
@@ -289,6 +329,10 @@ bool (*remove_user_default)(char *name);
     [_defaults setBool:dim forKey:kPreferenceDisableDimmingKey];
 }
 
+- (BOOL)validateShouldDisableDimming:(id *)value error:(NSError **)error {
+    return [*value isKindOfClass:NSNumber.class];
+}
+
 // MARK: launchCommand
 - (NSArray<NSString *> *)launchCommand {
     return [_defaults stringArrayForKey:kPreferenceLaunchCommandKey];
@@ -296,6 +340,18 @@ bool (*remove_user_default)(char *name);
 
 - (void)setLaunchCommand:(NSArray<NSString *> *)launchCommand {
     [_defaults setObject:launchCommand forKey:kPreferenceLaunchCommandKey];
+}
+
+- (BOOL)validateLaunchCommand:(id *)value error:(NSError **)error {
+    if (![*value isKindOfClass:NSArray.class]) {
+        return NO;
+    }
+    for (id element in (NSArray *)(*value)) {
+        if (![element isKindOfClass:NSString.class]) {
+            return NO;
+        }
+    }
+    return YES;
 }
 
 - (BOOL)hasChangedLaunchCommand {
@@ -312,6 +368,18 @@ bool (*remove_user_default)(char *name);
     [_defaults setObject:bootCommand forKey:kPreferenceBootCommandKey];
 }
 
+- (BOOL)validateBootCommand:(id *)value error:(NSError **)error {
+    if (![*value isKindOfClass:NSArray.class]) {
+        return NO;
+    }
+    for (id element in (NSArray *)(*value)) {
+        if (![element isKindOfClass:NSString.class]) {
+            return NO;
+        }
+    }
+    return YES;
+}
+
 // MARK: hideStatusBar
 - (BOOL)hideStatusBar {
     return [_defaults boolForKey:kPreferenceHideStatusBarKey];
@@ -319,6 +387,10 @@ bool (*remove_user_default)(char *name);
 
 - (void)setHideStatusBar:(BOOL)showStatusBar {
     [_defaults setBool:showStatusBar forKey:kPreferenceHideStatusBarKey];
+}
+
+- (BOOL)validateHideStatusBar:(id *)value error:(NSError **)error {
+    return [*value isKindOfClass:NSNumber.class];
 }
 
 @end

--- a/app/UserPreferences.m
+++ b/app/UserPreferences.m
@@ -11,15 +11,15 @@
 static NSString *const kPreferenceCapsLockMappingKey = @"Caps Lock Mapping";
 static NSString *const kPreferenceOptionMappingKey = @"Option Mapping";
 static NSString *const kPreferenceBacktickEscapeKey = @"Backtick Mapping Escape";
-static NSString *const kPreferenceHideExtraKeysWithExternalKeyboard = @"Hide Extra Keys With External Keyboard";
-static NSString *const kPreferenceOverrideControlSpace = @"Override Control Space";
+static NSString *const kPreferenceHideExtraKeysWithExternalKeyboardKey = @"Hide Extra Keys With External Keyboard";
+static NSString *const kPreferenceOverrideControlSpaceKey = @"Override Control Space";
 static NSString *const kPreferenceFontFamilyKey = @"Font Family";
 static NSString *const kPreferenceFontSizeKey = @"Font Size";
 static NSString *const kPreferenceThemeKey = @"Theme";
 static NSString *const kPreferenceDisableDimmingKey = @"Disable Dimming";
 NSString *const kPreferenceLaunchCommandKey = @"Init Command";
 NSString *const kPreferenceBootCommandKey = @"Boot Command";
-NSString *const kPreferenceHideStatusBar = @"Status Bar";
+NSString *const kPreferenceHideStatusBarKey = @"Status Bar";
 
 @implementation UserPreferences {
     NSUserDefaults *_defaults;
@@ -49,71 +49,83 @@ NSString *const kPreferenceHideStatusBar = @"Status Bar";
             kPreferenceDisableDimmingKey: @(NO),
             kPreferenceLaunchCommandKey: @[@"/bin/login", @"-f", @"root"],
             kPreferenceBootCommandKey: @[@"/sbin/init"],
-            kPreferenceHideStatusBar: @(NO),
+            kPreferenceHideStatusBarKey: @(NO),
         }];
         _theme = [[Theme alloc] initWithProperties:[_defaults objectForKey:kPreferenceThemeKey]];
     }
     return self;
 }
 
-- (BOOL)hideStatusBar {
-    return [_defaults boolForKey:kPreferenceHideStatusBar];
-}
+// MARK: - Preference properties
 
-- (void)setHideStatusBar:(BOOL)showStatusBar {
-    [_defaults setBool:showStatusBar forKey:kPreferenceHideStatusBar];
-}
-
+// MARK: capsLockMapping
 - (CapsLockMapping)capsLockMapping {
     return [_defaults integerForKey:kPreferenceCapsLockMappingKey];
 }
+
 - (void)setCapsLockMapping:(CapsLockMapping)capsLockMapping {
     [_defaults setInteger:capsLockMapping forKey:kPreferenceCapsLockMappingKey];
 }
 
+// MARK: optionMapping
 - (OptionMapping)optionMapping {
     return [_defaults integerForKey:kPreferenceOptionMappingKey];
 }
+
 - (void)setOptionMapping:(OptionMapping)optionMapping {
     [_defaults setInteger:optionMapping forKey:kPreferenceOptionMappingKey];
 }
 
+// MARK: backtickMapEscape
 - (BOOL)backtickMapEscape {
     return [_defaults boolForKey:kPreferenceBacktickEscapeKey];
 }
+
 - (void)setBacktickMapEscape:(BOOL)backtickMapEscape {
     [_defaults setBool:backtickMapEscape forKey:kPreferenceBacktickEscapeKey];
 }
 
+// MARK: hideExtraKeysWithExternalKeyboard
 - (BOOL)hideExtraKeysWithExternalKeyboard {
-    return [_defaults boolForKey:kPreferenceHideExtraKeysWithExternalKeyboard];
+    return [_defaults boolForKey:kPreferenceHideExtraKeysWithExternalKeyboardKey];
 }
+
 - (void)setHideExtraKeysWithExternalKeyboard:(BOOL)hideExtraKeysWithExternalKeyboard {
-    [_defaults setBool:hideExtraKeysWithExternalKeyboard forKey:kPreferenceHideExtraKeysWithExternalKeyboard];
+    [_defaults setBool:hideExtraKeysWithExternalKeyboard forKey:kPreferenceHideExtraKeysWithExternalKeyboardKey];
 }
+
+// MARK: overrideControlSpace
 - (BOOL)overrideControlSpace {
-    return [_defaults boolForKey:kPreferenceOverrideControlSpace];
+    return [_defaults boolForKey:kPreferenceOverrideControlSpaceKey];
 }
+
 - (void)setOverrideControlSpace:(BOOL)overrideControlSpace {
-    [_defaults setBool:overrideControlSpace forKey:kPreferenceOverrideControlSpace];
+    [_defaults setBool:overrideControlSpace forKey:kPreferenceOverrideControlSpaceKey];
 }
+
+// MARK: fontSize
 - (NSNumber *)fontSize {
     return [_defaults objectForKey:kPreferenceFontSizeKey];
 }
+
 - (void)setFontSize:(NSNumber *)fontSize {
     [_defaults setObject:fontSize forKey:kPreferenceFontSizeKey];
 }
 
+// MARK: fontFamily
 - (NSString *)fontFamily {
     return [_defaults objectForKey:kPreferenceFontFamilyKey];
 }
+
 - (void)setFontFamily:(NSString *)fontFamily {
     [_defaults setObject:fontFamily forKey:kPreferenceFontFamilyKey];
 }
 
+// MARK: theme
 - (UIColor *)foregroundColor {
     return self.theme.foregroundColor;
 }
+
 - (UIColor *)backgroundColor {
     return self.theme.backgroundColor;
 }
@@ -123,29 +135,45 @@ NSString *const kPreferenceHideStatusBar = @"Status Bar";
     [_defaults setObject:theme.properties forKey:kPreferenceThemeKey];
 }
 
+// MARK: shouldDisableDimming
 - (BOOL)shouldDisableDimming {
     return [_defaults boolForKey:kPreferenceDisableDimmingKey];
 }
+
 - (void)setShouldDisableDimming:(BOOL)dim {
     [_defaults setBool:dim forKey:kPreferenceDisableDimmingKey];
 }
 
+// MARK: launchCommand
 - (NSArray<NSString *> *)launchCommand {
     return [_defaults stringArrayForKey:kPreferenceLaunchCommandKey];
 }
+
 - (void)setLaunchCommand:(NSArray<NSString *> *)launchCommand {
     [_defaults setObject:launchCommand forKey:kPreferenceLaunchCommandKey];
 }
+
 - (BOOL)hasChangedLaunchCommand {
     NSArray *defaultLaunchCommand = [[[NSUserDefaults alloc] initWithSuiteName:NSRegistrationDomain] stringArrayForKey:kPreferenceLaunchCommandKey];
     return ![self.launchCommand isEqual:defaultLaunchCommand];
 }
 
+// MARK: bootCommand
 - (NSArray<NSString *> *)bootCommand {
     return [_defaults stringArrayForKey:kPreferenceBootCommandKey];
 }
+
 - (void)setBootCommand:(NSArray<NSString *> *)bootCommand {
     [_defaults setObject:bootCommand forKey:kPreferenceBootCommandKey];
+}
+
+// MARK: hideStatusBar
+- (BOOL)hideStatusBar {
+    return [_defaults boolForKey:kPreferenceHideStatusBarKey];
+}
+
+- (void)setHideStatusBar:(BOOL)showStatusBar {
+    [_defaults setBool:showStatusBar forKey:kPreferenceHideStatusBarKey];
 }
 
 @end

--- a/fs/proc.h
+++ b/fs/proc.h
@@ -6,6 +6,7 @@
 
 struct proc_entry {
     struct proc_dir_entry *meta;
+    unsigned long index;
     pid_t_ pid;
     sdword_t fd; // typedef might not have been read yet
 };

--- a/fs/proc.h
+++ b/fs/proc.h
@@ -7,6 +7,8 @@
 struct proc_entry {
     struct proc_dir_entry *meta;
     unsigned long index;
+    char **child_names;
+    char *name;
     pid_t_ pid;
     sdword_t fd; // typedef might not have been read yet
 };
@@ -20,10 +22,6 @@ struct proc_data {
 struct proc_dir_entry {
     const char *name;
     mode_t_ mode;
-
-    // files that need extra resource management
-    void (*ref)(struct proc_entry *entry);
-    void (*unref)(struct proc_entry *entry);
     
     // file with dynamic name
     void (*getname)(struct proc_entry *entry, char *buf);
@@ -64,6 +62,9 @@ extern struct proc_children proc_ish_children;
 mode_t_ proc_entry_mode(struct proc_entry *entry);
 void proc_entry_getname(struct proc_entry *entry, char *buf);
 int proc_entry_stat(struct proc_entry *entry, struct statbuf *stat);
+void proc_entry_cleanup(struct proc_entry *entry);
+
+void free_string_array(char **array);
 
 bool proc_dir_read(struct proc_entry *entry, unsigned long *index, struct proc_entry *next_entry);
 

--- a/fs/proc.h
+++ b/fs/proc.h
@@ -30,6 +30,9 @@ struct proc_dir_entry {
 
     // file with custom show data function
     int (*show)(struct proc_entry *entry, struct proc_data *data);
+    
+    // file with a custom write function
+    int (*update)(struct proc_entry *entry, struct proc_data *data);
 
     // symlink
     int (*readlink)(struct proc_entry *entry, char *buf);

--- a/fs/proc.h
+++ b/fs/proc.h
@@ -36,6 +36,9 @@ struct proc_dir_entry {
 
     // symlink
     int (*readlink)(struct proc_entry *entry, char *buf);
+    
+    // remove
+    int (*unlink)(struct proc_entry *entry);
 
     // directory with static list
     struct proc_children *children;

--- a/fs/proc.h
+++ b/fs/proc.h
@@ -56,7 +56,7 @@ int proc_entry_stat(struct proc_entry *entry, struct statbuf *stat);
 
 bool proc_dir_read(struct proc_entry *entry, unsigned long *index, struct proc_entry *next_entry);
 
-void proc_buf_write(struct proc_data *buf, const void *data, size_t size);
+void proc_buf_append(struct proc_data *buf, const void *data, size_t size);
 void proc_printf(struct proc_data *buf, const char *format, ...);
 
 #endif

--- a/fs/proc.h
+++ b/fs/proc.h
@@ -20,6 +20,10 @@ struct proc_dir_entry {
     const char *name;
     mode_t_ mode;
 
+    // files that need extra resource management
+    void (*ref)(struct proc_entry *entry);
+    void (*unref)(struct proc_entry *entry);
+    
     // file with dynamic name
     void (*getname)(struct proc_entry *entry, char *buf);
 

--- a/fs/proc/entry.c
+++ b/fs/proc/entry.c
@@ -61,3 +61,16 @@ bool proc_dir_read(struct proc_entry *entry, unsigned long *index, struct proc_e
     assert(!"read from invalid proc directory");
 }
 
+void free_string_array(char **array) {
+    for (int i = 0; array[i] != NULL; i++)
+        free(array[i]);
+    free(array);
+}
+
+void proc_entry_cleanup(struct proc_entry *entry) {
+    if (entry->name != NULL)
+        free(entry->name);
+    if (entry->child_names != NULL)
+        free_string_array(entry->child_names);
+    *entry = (struct proc_entry) {0};
+}

--- a/fs/proc/ish.c
+++ b/fs/proc/ish.c
@@ -7,87 +7,94 @@
 #include <sys/stat.h>
 
 const char *proc_ish_version = "";
-struct all_user_default_keys user_default_keys;
-void (*user_default_keys_requisition)(void);
-void (*user_default_keys_relinquish)(void);
-bool (*get_user_default)(char *name, char **buffer, size_t *size);
-bool (*set_user_default)(char *name, char *buffer, size_t size);
-bool (*remove_user_default)(char *name);
-
-static void proc_ish_defaults_initialize(struct proc_entry *UNUSED(entry)) {
-    user_default_keys_requisition();
-}
-
-static void proc_ish_defaults_deinitialize(struct proc_entry *UNUSED(entry)) {
-    user_default_keys_relinquish();
-}
-
-static void proc_ish__defaults_getname(struct proc_entry *entry, char *buf) {
-    strcpy(buf, user_default_keys.entries[entry->index].underlying_name);
-}
+char **(*get_all_defaults_keys)(void);
+char *(*get_friendly_name)(const char *name);
+char *(*get_underlying_name)(const char *name);
+bool (*get_user_default)(const char *name, char **buffer, size_t *size);
+bool (*set_user_default)(const char *name, char *buffer, size_t size);
+bool (*remove_user_default)(const char *name);
 
 static void proc_ish_defaults_getname(struct proc_entry *entry, char *buf) {
-    strcpy(buf, user_default_keys.entries[entry->index].name);
+    strcpy(buf, entry->name);
 }
 
 static int proc_ish_defaults_readlink(struct proc_entry *entry, char *buf) {
-    sprintf(buf, "../.defaults/%s", user_default_keys.entries[entry->index].underlying_name);
+    char *name = get_underlying_name(entry->name);
+    sprintf(buf, "../.defaults/%s", name);
+    free(name);
     return 0;
 }
 
-static int proc_ish__defaults_show(struct proc_entry *entry, struct proc_data *data) {
+static int proc_ish_underlying_defaults_show(struct proc_entry *entry, struct proc_data *data) {
     size_t size;
     char *buffer;
-    if (get_user_default(user_default_keys.entries[entry->index].underlying_name, &buffer, &size)) {
-        proc_buf_append(data, buffer, size);
-        free(buffer);
-        return 0;
-    } else {
+    if (!get_user_default(entry->name, &buffer, &size))
         return _EIO;
-    }
+    proc_buf_append(data, buffer, size);
+    free(buffer);
+    return 0;
 }
 
-static int proc_ish__defaults_update(struct proc_entry *entry, struct proc_data *data) {
-    if (set_user_default(user_default_keys.entries[entry->index].underlying_name, data->data, data->size)) {
-        return 0;
-    } else {
+static int proc_ish_underlying_defaults_update(struct proc_entry *entry, struct proc_data *data) {
+    if (!set_user_default(entry->name, data->data, data->size))
         return _EIO;
-    }
+    return 0;
+}
+
+static int proc_ish_underlying_defaults_unlink(struct proc_entry *entry) {
+    return remove_user_default(entry->name) ? 0 : _EIO;
 }
 
 static int proc_ish_defaults_unlink(struct proc_entry *entry) {
-    return remove_user_default(user_default_keys.entries[entry->index].underlying_name) ? 0 : _EIO;
+    char *name = get_underlying_name(entry->name);
+    int err = remove_user_default(name) ? 0 : _EIO;
+    free(name);
+    return err;
 }
 
-struct proc_dir_entry proc_ish__defaults_fd = { NULL,
-    .ref = proc_ish_defaults_initialize,
-    .unref = proc_ish_defaults_deinitialize,
-    .getname = proc_ish__defaults_getname,
-    .show = proc_ish__defaults_show,
-    .update = proc_ish__defaults_update,
-    .unlink = proc_ish_defaults_unlink
+struct proc_dir_entry proc_ish_underlying_defaults_fd = { NULL,
+    .getname = proc_ish_defaults_getname,
+    .show = proc_ish_underlying_defaults_show,
+    .update = proc_ish_underlying_defaults_update,
+    .unlink = proc_ish_underlying_defaults_unlink,
 };
 struct proc_dir_entry proc_ish_defaults_fd = { NULL, S_IFLNK,
-    .ref = proc_ish_defaults_initialize,
-    .unref = proc_ish_defaults_deinitialize,
     .getname = proc_ish_defaults_getname,
     .readlink = proc_ish_defaults_readlink,
-    .unlink = proc_ish_defaults_unlink
+    .unlink = proc_ish_defaults_unlink,
 };
 
-static bool proc_ish__defaults_readdir(struct proc_entry *UNUSED(entry), unsigned long *index, struct proc_entry *next_entry) {
-    *next_entry = (struct proc_entry){&proc_ish__defaults_fd, .index = *index, .fd = *index};
-    ++(*index);
-    return *index < user_default_keys.count;
+static void get_child_names(struct proc_entry *entry, unsigned long index) {
+    if (index == 0 || entry->child_names == NULL) {
+        if (entry->child_names != NULL)
+            free_string_array(entry->child_names);
+        entry->child_names = get_all_defaults_keys();
+    }
 }
 
-static bool proc_ish_defaults_readdir(struct proc_entry *UNUSED(entry), unsigned long *index, struct proc_entry *next_entry) {
-    while (*index < user_default_keys.count && !user_default_keys.entries[*index].name) {
-        ++(*index);
-    }
-    *next_entry = (struct proc_entry){&proc_ish_defaults_fd, .index = *index, .fd = *index};
-    ++(*index);
-    return *index < user_default_keys.count;
+static bool proc_ish_underlying_defaults_readdir(struct proc_entry *entry, unsigned long *index, struct proc_entry *next_entry) {
+    get_child_names(entry, *index);
+    if (entry->child_names[*index] == NULL)
+        return false;
+    next_entry->meta = &proc_ish_underlying_defaults_fd;
+    next_entry->name = strdup(entry->child_names[*index]);
+    (*index)++;
+    return true;
+}
+
+static bool proc_ish_defaults_readdir(struct proc_entry *entry, unsigned long *index, struct proc_entry *next_entry) {
+    get_child_names(entry, *index);
+    char *friendly_name;
+    do {
+        const char *name = entry->child_names[*index];
+        if (name == NULL)
+            return false;
+        friendly_name = get_friendly_name(name);
+        (*index)++;
+    } while (friendly_name == NULL);
+    next_entry->meta = &proc_ish_defaults_fd;
+    next_entry->name = friendly_name;
+    return true;
 }
 
 static int proc_ish_show_version(struct proc_entry *UNUSED(entry), struct proc_data *buf) {
@@ -96,16 +103,7 @@ static int proc_ish_show_version(struct proc_entry *UNUSED(entry), struct proc_d
 }
 
 struct proc_children proc_ish_children = PROC_CHILDREN({
-    {".defaults", S_IFDIR,
-        .ref = proc_ish_defaults_initialize,
-        .unref = proc_ish_defaults_deinitialize,
-        .readdir = proc_ish__defaults_readdir,
-    },
-    {"defaults", S_IFDIR,
-        .ref = proc_ish_defaults_initialize,
-        .unref = proc_ish_defaults_deinitialize,
-        .readdir = proc_ish_defaults_readdir,
-    },
+    {".defaults", S_IFDIR, .readdir = proc_ish_underlying_defaults_readdir},
+    {"defaults", S_IFDIR, .readdir = proc_ish_defaults_readdir},
     {"version", .show = proc_ish_show_version},
 });
-

--- a/fs/proc/ish.c
+++ b/fs/proc/ish.c
@@ -1,7 +1,94 @@
 #include "fs/proc.h"
+#include "fs/proc/ish.h"
+#include "kernel/errno.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 
 const char *proc_ish_version = "";
+struct all_user_default_keys user_default_keys;
+void (*user_default_keys_requisition)(void);
+void (*user_default_keys_relinquish)(void);
+bool (*get_user_default)(char *name, char **buffer, size_t *size);
+bool (*set_user_default)(char *name, char *buffer, size_t size);
+bool (*remove_user_default)(char *name);
+
+static void proc_ish_defaults_initialize(struct proc_entry *UNUSED(entry)) {
+    user_default_keys_requisition();
+}
+
+static void proc_ish_defaults_deinitialize(struct proc_entry *UNUSED(entry)) {
+    user_default_keys_relinquish();
+}
+
+static void proc_ish__defaults_getname(struct proc_entry *entry, char *buf) {
+    strcpy(buf, user_default_keys.entries[entry->index].underlying_name);
+}
+
+static void proc_ish_defaults_getname(struct proc_entry *entry, char *buf) {
+    strcpy(buf, user_default_keys.entries[entry->index].name);
+}
+
+static int proc_ish_defaults_readlink(struct proc_entry *entry, char *buf) {
+    sprintf(buf, "../.defaults/%s", user_default_keys.entries[entry->index].underlying_name);
+    return 0;
+}
+
+static int proc_ish__defaults_show(struct proc_entry *entry, struct proc_data *data) {
+    size_t size;
+    char *buffer;
+    if (get_user_default(user_default_keys.entries[entry->index].underlying_name, &buffer, &size)) {
+        proc_buf_append(data, buffer, size);
+        free(buffer);
+        return 0;
+    } else {
+        return _EIO;
+    }
+}
+
+static int proc_ish__defaults_update(struct proc_entry *entry, struct proc_data *data) {
+    if (set_user_default(user_default_keys.entries[entry->index].underlying_name, data->data, data->size)) {
+        return 0;
+    } else {
+        return _EIO;
+    }
+}
+
+static int proc_ish_defaults_unlink(struct proc_entry *entry) {
+    return remove_user_default(user_default_keys.entries[entry->index].underlying_name) ? 0 : _EIO;
+}
+
+struct proc_dir_entry proc_ish__defaults_fd = { NULL,
+    .ref = proc_ish_defaults_initialize,
+    .unref = proc_ish_defaults_deinitialize,
+    .getname = proc_ish__defaults_getname,
+    .show = proc_ish__defaults_show,
+    .update = proc_ish__defaults_update,
+    .unlink = proc_ish_defaults_unlink
+};
+struct proc_dir_entry proc_ish_defaults_fd = { NULL, S_IFLNK,
+    .ref = proc_ish_defaults_initialize,
+    .unref = proc_ish_defaults_deinitialize,
+    .getname = proc_ish_defaults_getname,
+    .readlink = proc_ish_defaults_readlink,
+    .unlink = proc_ish_defaults_unlink
+};
+
+static bool proc_ish__defaults_readdir(struct proc_entry *UNUSED(entry), unsigned long *index, struct proc_entry *next_entry) {
+    *next_entry = (struct proc_entry){&proc_ish__defaults_fd, .index = *index, .fd = *index};
+    ++(*index);
+    return *index < user_default_keys.count;
+}
+
+static bool proc_ish_defaults_readdir(struct proc_entry *UNUSED(entry), unsigned long *index, struct proc_entry *next_entry) {
+    while (*index < user_default_keys.count && !user_default_keys.entries[*index].name) {
+        ++(*index);
+    }
+    *next_entry = (struct proc_entry){&proc_ish_defaults_fd, .index = *index, .fd = *index};
+    ++(*index);
+    return *index < user_default_keys.count;
+}
 
 static int proc_ish_show_version(struct proc_entry *UNUSED(entry), struct proc_data *buf) {
     proc_printf(buf, "%s\n", proc_ish_version);
@@ -9,6 +96,16 @@ static int proc_ish_show_version(struct proc_entry *UNUSED(entry), struct proc_d
 }
 
 struct proc_children proc_ish_children = PROC_CHILDREN({
+    {".defaults", S_IFDIR,
+        .ref = proc_ish_defaults_initialize,
+        .unref = proc_ish_defaults_deinitialize,
+        .readdir = proc_ish__defaults_readdir,
+    },
+    {"defaults", S_IFDIR,
+        .ref = proc_ish_defaults_initialize,
+        .unref = proc_ish_defaults_deinitialize,
+        .readdir = proc_ish_defaults_readdir,
+    },
     {"version", .show = proc_ish_show_version},
 });
 

--- a/fs/proc/ish.h
+++ b/fs/proc/ish.h
@@ -6,16 +6,9 @@ struct user_default_key {
     char *underlying_name;
 };
 
-struct all_user_default_keys {
-    struct user_default_key *entries;
-    size_t count;
-};
-
-extern struct all_user_default_keys user_default_keys;
-
-extern void (*user_default_keys_requisition)(void);
-extern void (*user_default_keys_relinquish)(void);
-
-extern bool (*get_user_default)(char *name, char **buffer, size_t *size);
-extern bool (*set_user_default)(char *name, char *buffer, size_t size);
-extern bool (*remove_user_default)(char *name);
+extern char **(*get_all_defaults_keys)(void);
+extern char *(*get_friendly_name)(const char *name);
+extern char *(*get_underlying_name)(const char *name);
+extern bool (*get_user_default)(const char *name, char **buffer, size_t *size);
+extern bool (*set_user_default)(const char *name, char *buffer, size_t size);
+extern bool (*remove_user_default)(const char *name);

--- a/fs/proc/ish.h
+++ b/fs/proc/ish.h
@@ -1,0 +1,21 @@
+#include <stddef.h>
+#include <stdbool.h>
+
+struct user_default_key {
+    char *name;
+    char *underlying_name;
+};
+
+struct all_user_default_keys {
+    struct user_default_key *entries;
+    size_t count;
+};
+
+extern struct all_user_default_keys user_default_keys;
+
+extern void (*user_default_keys_requisition)(void);
+extern void (*user_default_keys_relinquish)(void);
+
+extern bool (*get_user_default)(char *name, char **buffer, size_t *size);
+extern bool (*set_user_default)(char *name, char *buffer, size_t size);
+extern bool (*remove_user_default)(char *name);

--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -119,7 +119,7 @@ static int proc_pid_auxv_show(struct proc_entry *entry, struct proc_data *buf) {
         goto out_free_task;
     }
     if (user_read_task(task, task->mm->auxv_start, data, size) == 0)
-        proc_buf_write(buf, data, size);
+        proc_buf_append(buf, data, size);
     free(data);
 
 out_free_task:
@@ -144,7 +144,7 @@ static int proc_pid_cmdline_show(struct proc_entry *entry, struct proc_data *buf
         goto out_free_task;
     }
     if (user_read_task(task, task->mm->argv_start, data, size) == 0)
-        proc_buf_write(buf, data, size);
+        proc_buf_append(buf, data, size);
     free(data);
 
 out_free_task:

--- a/fs/proc/root.c
+++ b/fs/proc/root.c
@@ -109,7 +109,7 @@ struct proc_dir_entry proc_root_entries[] = {
 
 static bool proc_root_readdir(struct proc_entry *UNUSED(entry), unsigned long *index, struct proc_entry *next_entry) {
     if (*index < PROC_ROOT_LEN) {
-        *next_entry = (struct proc_entry) {&proc_root_entries[*index], 0, 0};
+        *next_entry = (struct proc_entry) {&proc_root_entries[*index], *index, 0, 0};
         (*index)++;
         return true;
     }

--- a/iSH.xcodeproj/project.pbxproj
+++ b/iSH.xcodeproj/project.pbxproj
@@ -381,6 +381,7 @@
 		408A2639236440F8008A4E81 /* iOSFS.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iOSFS.m; sourceTree = "<group>"; };
 		408A263B23644102008A4E81 /* iOSFS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iOSFS.h; sourceTree = "<group>"; };
 		49302D8D277669D300C9885A /* ish.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ish.c; sourceTree = "<group>"; };
+		49302D972777FAB400C9885A /* ish.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ish.h; sourceTree = "<group>"; };
 		494D03F72727DAC6004F0CCE /* xcode-ninja.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xcode-ninja.sh"; sourceTree = "<group>"; };
 		497F6BDA254E5C0D00C82F46 /* mem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mem.h; sourceTree = "<group>"; };
 		497F6BDB254E5C0D00C82F46 /* path.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = path.c; sourceTree = "<group>"; };
@@ -745,6 +746,7 @@
 			children = (
 				497F6BF4254E5C0D00C82F46 /* entry.c */,
 				49302D8D277669D300C9885A /* ish.c */,
+				49302D972777FAB400C9885A /* ish.h */,
 				497F6BF2254E5C0D00C82F46 /* pid.c */,
 				497F6BF3254E5C0D00C82F46 /* root.c */,
 			);


### PR DESCRIPTION
High level design:

* User defaults are now available via /proc/ish/defaults and /proc/ish/.defaults. The latter is "all" preferences and the former symlinks into it for "friendly" names and to indicate that these are preferences we explicitly support you changing.
* Removing the file, as well as reading and writing to it is supported. This is roughly equivalent to reseting the preference, getting it, and setting it.
* Preferences are exposed via JSON fragments.