### PR TITLE
Handle AT_EMPTY_PATH for fstatat64

### DIFF
--- a/fs/mount.c
+++ b/fs/mount.c
@@ -155,7 +155,7 @@ dword_t sys_mount(addr_t source_addr, addr_t point_addr, addr_t type_addr, dword
         return _EINVAL;
 
     struct statbuf stat;
-    int err = generic_statat(AT_PWD, point_raw, &stat, true);
+    int err = generic_statat(AT_PWD, point_raw, &stat, 0);
     if (err < 0)
         return err;
     if (!S_ISDIR(stat.mode))

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -561,7 +561,7 @@ dword_t sys_getcwd(addr_t buf_addr, dword_t size) {
 
 static struct fd *open_dir(const char *path) {
     struct statbuf stat;
-    int err = generic_statat(AT_PWD, path, &stat, true);
+    int err = generic_statat(AT_PWD, path, &stat, 0);
     if (err < 0)
         return ERR_PTR(err);
     if (!(stat.mode & S_IFDIR))

--- a/kernel/fs.h
+++ b/kernel/fs.h
@@ -44,6 +44,7 @@ struct attr {
 #define make_attr(_type, thing) \
     ((struct attr) {.type = attr_##_type, ._type = thing})
 
+#define AT_EMPTY_PATH_ 0x1000
 #define AT_SYMLINK_NOFOLLOW_ 0x100
 
 struct fd *generic_open(const char *path, int flags, int mode);
@@ -61,7 +62,7 @@ int generic_seek(struct fd *fd, off_t_ off, int whence, size_t size);
 #define AC_X 1
 #define AC_F 0
 int generic_accessat(struct fd *dirfd, const char *path, int mode);
-int generic_statat(struct fd *at, const char *path, struct statbuf *stat, bool follow_links);
+int generic_statat(struct fd *at, const char *path, struct statbuf *stat, int flags);
 int generic_setattrat(struct fd *at, const char *path, struct attr attr, bool follow_links);
 int generic_utime(struct fd *at, const char *path, struct timespec atime, struct timespec mtime, bool follow_links);
 ssize_t generic_readlinkat(struct fd *at, const char *path, char *buf, size_t bufsize);


### PR DESCRIPTION
This PR adds correct handling for the `AT_EMPTY_PATH` flag in `fstatat64`. `AT_EMPTY_PATH` allows an empty string to be specified as the path, in which case `fstatat` should operate on the file pointed at by the fd itself:

```
       AT_EMPTY_PATH (since Linux 2.6.39)
              If pathname is an empty string, operate on the file
              referred to by dirfd (which may have been obtained using
              the open(2) O_PATH flag).  In this case, dirfd can refer
              to any type of file, not just a directory, and the
              behavior of fstatat() is similar to that of fstat().  If
              dirfd is AT_FDCWD, the call operates on the current
              working directory.  This flag is Linux-specific; define
              _GNU_SOURCE to obtain its definition.

```

This behavior is relied on by newer glibc when loading shared objects. Currently we return `-ENOENT` for empty paths, leading to behavior like:

```console
/ # bash
bash: error while loading shared libraries: libreadline.so.8: cannot stat shared object: No such file or directory
/ # dmesg
[snip]
2 call 295 openat(-100, "/nix/store/kslb3am4237in6m7i6qi210vc6w7rsfn-readline-8.1p2/lib/libreadline.so.8", 0x88000, 0x0) = 0x3
2 call 3   read(3, 0xffffd110, 512) "ELF" = 0x200
2 call 180 pread(3, 0xffffcee0, 40, 314308) "" = 0x28
2 call 300 stat(at=3, path="", statbuf=0xffffce78, follow_links=1) = 0xfffffffe
2 call 6   close(3) = 0x0
2 call 146 writev(2, 0xffffcd90, 10) {"bash", 4} {": ", 2} {"error while loading shared libraries", 36} {": ", 2} {"libreadline.so.8", 16} {": ", 2} {"cannot stat shared object", 25} {": ", 2} {"No such file or directory", 25} {"
", 1} = 0x73
2 call 252 exit_group(127)
```

With the fix:

```console
/ # bash
bash-5.1# exit
/ # dmesg
[snip]
4 call 295 openat(-100, "/nix/store/kslb3am4237in6m7i6qi210vc6w7rsfn-readline-8.1p2/lib/libreadline.so.8", 0x88000, 0x0) = 0x3
4 call 3   read(3, 0xffffd110, 512) "ELF" = 0x200
4 call 180 pread(3, 0xffffcee0, 40, 314308) "" = 0x28
4 call 300 stat(at=3, path="", statbuf=0xffffce78, flags=0x1000) = 0x0
```

Note that many glibc programs are still broken. I'm playing around with getting a Nix-based environment running in iSH and while I was able to start bash and run some small programs, Nix itself still doesn't run:

- `getcontext()` and `setcontext()` save and restore `fs` (#370)
	- `5 illegal instruction at 0xf749e35f: 66 8c e2 89 50 18 8d 88` ([`mov dx, fs`](https://github.com/bminor/glibc/blob/a01a13601c95f5d111d25557656d09fe661cfc89/sysdeps/unix/sysv/linux/i386/getcontext.S#L42))
- Need to implement/stub more syscalls: 126 (sigprocmask), 435 (clone3)
- ... and more, because Nix still hangs after some quick hacks