### PR TITLE
Fix/webview terminal size spacing

### DIFF
--- a/app/TerminalView.m
+++ b/app/TerminalView.m
@@ -118,6 +118,7 @@ static NSString *const HANDLERS[] = {@"syncFocus", @"focus", @"newScrollHeight",
     }
 
     WKWebView *webView = _terminal.webView;
+    CGSize screen = UIScreen.mainScreen.bounds.size;
     _terminal.enableVoiceOverAnnounce = YES;
     webView.scrollView.scrollEnabled = NO;
     webView.scrollView.delaysContentTouches = NO;
@@ -127,7 +128,7 @@ static NSString *const HANDLERS[] = {@"syncFocus", @"focus", @"newScrollHeight",
     for (int i = 0; i < sizeof(HANDLERS)/sizeof(HANDLERS[0]); i++) {
         [webView.configuration.userContentController addScriptMessageHandler:handler name:HANDLERS[i]];
     }
-    webView.frame = self.bounds;
+    webView.frame = CGRectMake(0, 0, screen.width + 13, self.bounds.size.height + 12);
     self.opaque = webView.opaque = NO;
     webView.backgroundColor = UIColor.clearColor;
     webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;


### PR DESCRIPTION
This PR allows the web view to be the full width of the screen. This is only really noticeable when an app has a different background colour to the ish theme but it's annoying either way.