### PR TITLE
added nullptr check (previously segfaulted)

### DIFF
--- a/fs/path.c
+++ b/fs/path.c
@@ -120,7 +120,7 @@ static int __path_normalize(const char *at_path, const char *path, char *out, in
 
 int path_normalize(struct fd *at, const char *path, char *out, int flags) {
     assert(at != NULL);
-    if ((path == NULL) || (strcmp(path, "") == 0))
+    if ((strcmp(path, "") == 0))
         return _ENOENT;
 
     // start with root or cwd, depending on whether it starts with a slash

--- a/fs/path.c
+++ b/fs/path.c
@@ -120,7 +120,7 @@ static int __path_normalize(const char *at_path, const char *path, char *out, in
 
 int path_normalize(struct fd *at, const char *path, char *out, int flags) {
     assert(at != NULL);
-    if (strcmp(path, "") == 0)
+    if ((path == NULL) || (strcmp(path, "") == 0))
         return _ENOENT;
 
     // start with root or cwd, depending on whether it starts with a slash

--- a/fs/path.c
+++ b/fs/path.c
@@ -120,7 +120,7 @@ static int __path_normalize(const char *at_path, const char *path, char *out, in
 
 int path_normalize(struct fd *at, const char *path, char *out, int flags) {
     assert(at != NULL);
-    if ((strcmp(path, "") == 0))
+    if (strcmp(path, "") == 0)
         return _ENOENT;
 
     // start with root or cwd, depending on whether it starts with a slash

--- a/xX_main_Xx.h
+++ b/xX_main_Xx.h
@@ -104,7 +104,7 @@ static inline int xX_main_Xx(int argc, char *const argv[], const char *envp) {
     }
     argv_copy[p] = '\0';
     if (argv[optind] == NULL)
-	return _ENOENT;
+	 return _ENOENT;
     err = do_execve(argv[optind], argc - optind, argv_copy, envp == NULL ? "\0" : envp);
     if (err < 0)
         return err;

--- a/xX_main_Xx.h
+++ b/xX_main_Xx.h
@@ -104,7 +104,7 @@ static inline int xX_main_Xx(int argc, char *const argv[], const char *envp) {
     }
     argv_copy[p] = '\0';
     if (argv[optind] == NULL)
-	 return _ENOENT;
+	    return _ENOENT;
     err = do_execve(argv[optind], argc - optind, argv_copy, envp == NULL ? "\0" : envp);
     if (err < 0)
         return err;

--- a/xX_main_Xx.h
+++ b/xX_main_Xx.h
@@ -103,6 +103,8 @@ static inline int xX_main_Xx(int argc, char *const argv[], const char *envp) {
         i++;
     }
     argv_copy[p] = '\0';
+    if (argv[optind] == NULL)
+	return _ENOENT;
     err = do_execve(argv[optind], argc - optind, argv_copy, envp == NULL ? "\0" : envp);
     if (err < 0)
         return err;


### PR DESCRIPTION
Running ./ish with no command line argument resulted in a segmentation fault.

On line 106 in xX_main_Xx.h, the first argument of do_execve() received a nullptr, but no adequate checks were provided to handle nullptr. The nullptr is then passed into strcmp(), which resulted in undefined behaviors (segfaulted on my system).

So a check for (path == NULL) was provided in path_normalize(), so _ENOENT can be returned instead of undefined behavior from passing NULL into strcmp().