### PR TITLE
meson: fix warnings

### DIFF
--- a/deps/meson.build
+++ b/deps/meson.build
@@ -39,7 +39,8 @@ if get_option('kernel') == 'linux'
     run_command('mkdir', [
         '-p',
         meson.current_build_dir()+'/linux/include/generated/uapi',
-        meson.current_build_dir()+'/linux/arch/ish/include/generated/uapi'])
+        meson.current_build_dir()+'/linux/arch/ish/include/generated/uapi']
+        check: false)
 
     linux_headers = declare_dependency(
         include_directories: [include_directories(

--- a/deps/meson.build
+++ b/deps/meson.build
@@ -39,7 +39,7 @@ if get_option('kernel') == 'linux'
     run_command('mkdir', [
         '-p',
         meson.current_build_dir()+'/linux/include/generated/uapi',
-        meson.current_build_dir()+'/linux/arch/ish/include/generated/uapi']
+        meson.current_build_dir()+'/linux/arch/ish/include/generated/uapi'],
         check: false)
 
     linux_headers = declare_dependency(

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -24,9 +24,9 @@ endif
 libarchive = dependency('libarchive', required: false)
 if not libarchive.found()
     # homebrew
-    libarchive_lib = cc.find_library('libarchive', dirs: ['/usr/local/opt/libarchive/lib'], required: false)
+    libarchive_lib = cc.find_library('archive', dirs: ['/usr/local/opt/libarchive/lib'], required: false)
     if not libarchive_lib.found()
-        libarchive_lib = cc.find_library('libarchive', dirs: ['/opt/homebrew/opt/libarchive/lib'], required: false)
+        libarchive_lib = cc.find_library('archive', dirs: ['/opt/homebrew/opt/libarchive/lib'], required: false)
     endif
     if libarchive_lib.found()
         libarchive = declare_dependency(dependencies: [libarchive_lib], include_directories: include_directories(['/usr/local/opt/libarchive/include']))

--- a/vdso/meson.build
+++ b/vdso/meson.build
@@ -8,7 +8,7 @@
 # Default install paths for Homebrew on Intel, Homebrew on Apple silicon, and MacPorts, respectively.
 clang = find_program('/usr/local/opt/llvm/bin/clang', '/opt/homebrew/opt/llvm/bin/clang', '/opt/local/bin/clang', 'clang')
 check_cc = find_program('check-cc.sh')
-result = run_command(check_cc, clang)
+result = run_command(check_cc, clang, check: false)
 if result.returncode() != 0
     message('\n' + result.stdout() + result.stderr())
     if build_machine.system() == 'darwin'


### PR DESCRIPTION
Fixes the following:
```
WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in future releases of meson.
         See also: https://github.com/mesonbuild/meson/issues/9300
```
and
```
WARNING: find_library('libarchive') starting in "lib" only works by accident and is not portable
```
