### PR TITLE
Patch out web view focus stealing first responder

### DIFF
--- a/app/AccessibilityFixes.m
+++ b/app/AccessibilityFixes.m
@@ -1,0 +1,47 @@
+//
+//  AccessibilityFixes.m
+//  iSH
+//
+//  Created by Saagar Jha on 12/31/22.
+//
+
+#import "hook.h"
+#import <UIKit/UIKit.h>
+#import <assert.h>
+#import <dlfcn.h>
+#import <objc/runtime.h>
+
+// Work around https://bugs.webkit.org/show_bug.cgi?id=249976, which causes
+// https://github.com/ish-app/ish/issues/1937.
+
+static void replacement(void) {
+    NSLog(@"Hooked PageClientImpl::assistiveTechnologyMakeFirstResponder");
+}
+
+static bool patched;
+
+static void patch_if_needed(void) {
+    if (!patched && UIAccessibilityIsVoiceOverRunning()) {
+        patched = true;
+        // This can take a little while.
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            Dl_info info;
+            dladdr((__bridge void *)objc_getClass("WKWebView"), &info);
+            void *symbol = find_symbol(info.dli_fbase, "__ZN6WebKit14PageClientImpl37assistiveTechnologyMakeFirstResponderEv");
+            bool hooked = hook((void *)symbol, (void *)replacement);
+            assert(hooked);
+        });
+    }
+}
+
+__attribute__((constructor)) void accessibilityfixes_init(void) {
+    if (@available(iOS 15.7, *)) {
+        [NSNotificationCenter.defaultCenter addObserverForName:UIAccessibilityVoiceOverStatusDidChangeNotification
+                                                        object:nil
+                                                         queue:nil
+                                                    usingBlock:^(NSNotification *notification) {
+            patch_if_needed();
+        }];
+        patch_if_needed();
+    }
+}

--- a/app/App.xcconfig
+++ b/app/App.xcconfig
@@ -9,4 +9,5 @@ ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon
 CODE_SIGN_ENTITLEMENTS = app/iSH.entitlements
 
 HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT) $(SRCROOT)/deps/libarchive/libarchive
-OTHER_LDFLAGS = -ObjC $(LINUX_APP_LDFLAGS)
+// AccessibilityFixes.m contains a static constructor that we don't want removed
+OTHER_LDFLAGS = -ObjC $(LINUX_APP_LDFLAGS) -u _accessibilityfixes_init

--- a/app/hook.c
+++ b/app/hook.c
@@ -1,0 +1,274 @@
+//
+//  hook.c
+//  iSH
+//
+//  Created by Saagar Jha on 12/29/22.
+//
+
+#include "hook.h"
+#include "mach_excServer.h"
+#include <CoreFoundation/CoreFoundation.h>
+#include <dlfcn.h>
+#include <mach-o/dyld_images.h>
+#include <mach-o/nlist.h>
+#include <mach/mach.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/sysctl.h>
+
+#if __arm64__
+
+kern_return_t catch_mach_exception_raise(
+    mach_port_t exception_port,
+    mach_port_t thread,
+    mach_port_t task,
+    exception_type_t exception,
+    mach_exception_data_t code,
+    mach_msg_type_number_t codeCnt) {
+    abort();
+}
+
+kern_return_t catch_mach_exception_raise_state_identity(
+    mach_port_t exception_port,
+    mach_port_t thread,
+    mach_port_t task,
+    exception_type_t exception,
+    mach_exception_data_t code,
+    mach_msg_type_number_t codeCnt,
+    int *flavor,
+    thread_state_t old_state,
+    mach_msg_type_number_t old_stateCnt,
+    thread_state_t new_state,
+    mach_msg_type_number_t *new_stateCnt) {
+    abort();
+}
+
+static bool initialized;
+
+struct hook {
+    uintptr_t old;
+    uintptr_t new;
+};
+static struct hook hooks[16];
+static int active_hooks;
+static int breakpoints;
+
+mach_port_t server;
+
+kern_return_t catch_mach_exception_raise_state(
+    mach_port_t exception_port,
+    exception_type_t exception,
+    const mach_exception_data_t code,
+    mach_msg_type_number_t codeCnt,
+    int *flavor,
+    const thread_state_t old_state,
+    mach_msg_type_number_t old_stateCnt,
+    thread_state_t new_state,
+    mach_msg_type_number_t *new_stateCnt) {
+    arm_thread_state64_t *old = (arm_thread_state64_t *)old_state;
+    arm_thread_state64_t *new = (arm_thread_state64_t *)new_state;
+
+    for (int i = 0; i < active_hooks; ++i) {
+        if (hooks[i].old == arm_thread_state64_get_pc(*old)) {
+            *new = *old;
+            *new_stateCnt = old_stateCnt;
+            arm_thread_state64_set_pc_fptr(*new, hooks[i].new);
+            return KERN_SUCCESS;
+        }
+    }
+
+    return KERN_FAILURE;
+}
+
+void *exception_handler(void *unused) {
+    mach_msg_server(mach_exc_server, sizeof(union __RequestUnion__catch_mach_exc_subsystem), server, MACH_MSG_OPTION_NONE);
+    abort();
+}
+
+static bool initialize_if_needed() {
+    if (initialized) {
+        return true;
+    }
+
+#define CHECK(x)          \
+    do {                  \
+        if (!(x)) {       \
+            return false; \
+        }                 \
+    } while (0)
+
+    size_t size = sizeof(breakpoints);
+    CHECK(!sysctlbyname("hw.optional.breakpoint", &breakpoints, &size, NULL, 0));
+
+    CHECK(mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE, &server) == KERN_SUCCESS);
+    CHECK(mach_port_insert_right(mach_task_self(), server, server, MACH_MSG_TYPE_MAKE_SEND) == KERN_SUCCESS);
+
+    // This will break any connected debuggers. Unfortunately the workarounds
+    // for this are not very good, so we're not going to bother with them.
+    CHECK(task_set_exception_ports(mach_task_self(), EXC_MASK_BREAKPOINT, server, EXCEPTION_STATE | MACH_EXCEPTION_CODES, ARM_THREAD_STATE64) == KERN_SUCCESS);
+
+    pthread_t thread;
+    CHECK(!pthread_create(&thread, NULL, exception_handler, NULL));
+
+#undef CHECK
+
+    return initialized = true;
+}
+
+// This is marked as available on iPhone in libproc.h but pulling in the header
+// on iOS is difficult, so we should just forward declare it.
+static int (*proc_regionfilename)(int pid, uint64_t address, void *buffer, uint32_t buffersize);
+
+// Pulled from https://github.com/apple-oss-distributions/dyld/blob/main/cache-builder/dyld_cache_format.h.
+// The format hasn't changed yet but we should check the magic value if it does,
+// since Apple's tools use it to detect if the layout will be updated.
+struct dyld_cache_header {
+    char magic[16];
+    char padding[56];
+    uint64_t localSymbolsOffset;
+    uint64_t localSymbolsSize;
+};
+
+struct dyld_cache_local_symbols_info {
+    uint32_t nlistOffset;
+    uint32_t nlistCount;
+    uint32_t stringsOffset;
+};
+
+void *find_symbol(void *base, char *symbol) {
+    if (!proc_regionfilename) {
+        proc_regionfilename = dlsym(dlopen(NULL, RTLD_LAZY), "proc_regionfilename");
+    }
+
+#define CHECK(x)         \
+    do {                 \
+        if (!(x)) {      \
+            return NULL; \
+        }                \
+    } while (0)
+
+    CHECK(proc_regionfilename);
+
+    task_dyld_info_data_t dyld_info;
+    mach_msg_type_number_t count = TASK_DYLD_INFO_COUNT;
+    CHECK(task_info(mach_task_self(), TASK_DYLD_INFO, (task_info_t)&dyld_info, &count) == KERN_SUCCESS);
+    struct dyld_all_image_infos *all_image_infos = (struct dyld_all_image_infos *)dyld_info.all_image_info_addr;
+
+    // proc_regionfilename doesn't seem to produce results unless the shared
+    // region has been modified in some way. This "no-op" forces the mapping
+    // to be backed by a vnode whose path we can query.
+    vm_protect(mach_task_self(), (vm_address_t)base, 1, false, VM_PROT_READ | VM_PROT_COPY);
+    vm_protect(mach_task_self(), (vm_address_t)base, 1, false, VM_PROT_READ | VM_PROT_EXECUTE);
+
+    char path[MAXPATHLEN];
+    int size = proc_regionfilename(getpid(), all_image_infos->sharedCacheBaseAddress, path, sizeof(path));
+    CHECK(size > 0);
+
+    CFURLRef region = CFURLCreateWithBytes(NULL, (UInt8 *)path, size, kCFStringEncodingUTF8, NULL);
+    CFURLRef shared_cache = CFURLCreateCopyDeletingPathExtension(NULL, region);
+    CFURLRef symbols_file = CFURLCreateCopyAppendingPathExtension(NULL, shared_cache, CFSTR("symbols"));
+    CFStringGetCString(CFURLGetString(symbols_file), path, sizeof(path), kCFStringEncodingUTF8);
+    CFRelease(region);
+    CFRelease(shared_cache);
+    CFRelease(symbols_file);
+
+    int fd = open(path, O_RDONLY);
+    CHECK(fd >= 0);
+
+    struct stat buffer;
+    CHECK(!stat(path, &buffer));
+
+    void *file = mmap(NULL, buffer.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    close(fd);
+    CHECK(file);
+
+#undef CHECK
+
+    void *address = NULL;
+
+    struct dyld_cache_header *header = (struct dyld_cache_header *)file;
+    if (strcmp(header->magic, "dyld_v1   arm64") && strcmp(header->magic, "dyld_v1  arm64e")) {
+        goto done;
+    }
+
+    struct dyld_cache_local_symbols_info *symbols = (struct dyld_cache_local_symbols_info *)(file + header->localSymbolsOffset);
+
+    struct nlist_64 *list = (struct nlist_64 *)(file + header->localSymbolsOffset + symbols->nlistOffset);
+    char *strings = (char *)(file + header->localSymbolsOffset + symbols->stringsOffset);
+    for (size_t i = 0; i < symbols->nlistCount; ++i) {
+        if (!strcmp(strings + list[i].n_un.n_strx, symbol)) {
+            uintptr_t _address = list[i].n_value + all_image_infos->sharedCacheSlide;
+            Dl_info info;
+            dladdr((void *)_address, &info);
+            if (info.dli_fbase == base) {
+                address = (void *)_address;
+                break;
+            }
+        }
+    }
+
+done:
+    munmap(file, buffer.st_size);
+    return address;
+}
+
+bool hook(void *old, void *new) {
+    initialize_if_needed();
+
+#define CHECK(x)          \
+    do {                  \
+        if (!(x)) {       \
+            return false; \
+        }                 \
+    } while (0)
+
+    CHECK(active_hooks < breakpoints);
+
+    arm_debug_state64_t state = {};
+    state.__bvr[active_hooks] = (uintptr_t)old;
+    // DBGBCR_EL1
+    //  .BT = 0b0000 << 20 (unlinked address match)
+    //  .BAS = 0xF << 5 (A64)
+    //  .PMC = 0b10 << 1 (user)
+    //  .E = 0b1 << 0 (enable)
+    state.__bcr[active_hooks] = 0x1e5;
+
+    CHECK(task_set_state(mach_task_self(), ARM_DEBUG_STATE64, (thread_state_t)&state, ARM_DEBUG_STATE64_COUNT) == KERN_SUCCESS);
+
+#undef CHECK
+
+    bool success = true;
+
+    thread_act_array_t threads;
+    mach_msg_type_number_t thread_count = ARM_DEBUG_STATE64_COUNT;
+    task_threads(mach_task_self(), &threads, &thread_count);
+    for (int i = 0; i < thread_count; ++i) {
+        if (thread_set_state(threads[i], ARM_DEBUG_STATE64, (thread_state_t)&state, ARM_DEBUG_STATE64_COUNT) != KERN_SUCCESS) {
+            success = false;
+            goto done;
+        }
+    }
+
+    hooks[active_hooks++] = (struct hook){(uintptr_t)old, (uintptr_t) new};
+
+done:
+    for (int i = 0; i < thread_count; ++i) {
+        mach_port_deallocate(mach_task_self(), threads[i]);
+    }
+    vm_deallocate(mach_task_self(), (vm_address_t)threads, thread_count * sizeof(*threads));
+
+    return success;
+}
+
+#else
+
+void *find_symbol(void *base, char *symbol) {
+    return NULL;
+}
+
+bool hook(void *old, void *new) {
+    return false;
+}
+
+#endif

--- a/app/hook.h
+++ b/app/hook.h
@@ -1,0 +1,16 @@
+//
+//  hook.h
+//  iSH
+//
+//  Created by Saagar Jha on 12/29/22.
+//
+
+#ifndef hook_h
+#define hook_h
+
+#include <stdbool.h>
+
+void *find_symbol(void *base, char *symbol);
+bool hook(void *old, void *new);
+
+#endif /* hook_h */

--- a/iSH.xcodeproj/project.pbxproj
+++ b/iSH.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		496C7AB327CC734D005D7613 /* ThemesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 491C4C1627C8F84A008B1DFA /* ThemesViewController.m */; };
 		497A08BF29633FF400B323CF /* mach_exc.defs in Sources */ = {isa = PBXBuildFile; fileRef = 49087C26295DF1350058075B /* mach_exc.defs */; settings = {ATTRIBUTES = (Server, ); }; };
 		497A08C029633FFA00B323CF /* hook.c in Sources */ = {isa = PBXBuildFile; fileRef = 49087C14295DF0490058075B /* hook.c */; };
+		497A08C12963401100B323CF /* AccessibilityFixes.m in Sources */ = {isa = PBXBuildFile; fileRef = 497A08BC2961168400B323CF /* AccessibilityFixes.m */; };
 		497F6CF5254E5EA500C82F46 /* float80-test.c in Sources */ = {isa = PBXBuildFile; fileRef = 497F6C5A254E5C7E00C82F46 /* float80-test.c */; };
 		497F6CF6254E5EA500C82F46 /* float80.c in Sources */ = {isa = PBXBuildFile; fileRef = 497F6C66254E5C7F00C82F46 /* float80.c */; };
 		497F6CF7254E5EA500C82F46 /* fpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 497F6C5D254E5C7E00C82F46 /* fpu.c */; };
@@ -428,6 +429,7 @@
 		49302D972777FAB400C9885A /* ish.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ish.h; sourceTree = "<group>"; };
 		493B378F290F5320000C41ED /* CLI.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = CLI.xcconfig; sourceTree = "<group>"; };
 		494D03F72727DAC6004F0CCE /* xcode-ninja.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xcode-ninja.sh"; sourceTree = "<group>"; };
+		497A08BC2961168400B323CF /* AccessibilityFixes.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AccessibilityFixes.m; sourceTree = "<group>"; };
 		497F6BDA254E5C0D00C82F46 /* mem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mem.h; sourceTree = "<group>"; };
 		497F6BDB254E5C0D00C82F46 /* path.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = path.c; sourceTree = "<group>"; };
 		497F6BDC254E5C0D00C82F46 /* dev.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dev.c; sourceTree = "<group>"; };
@@ -1279,6 +1281,7 @@
 				BB455E0F1FB37F6600AFB48B /* DelayedUITask.h */,
 				BB455E101FB37F6600AFB48B /* DelayedUITask.m */,
 				49087C14295DF0490058075B /* hook.c */,
+				497A08BC2961168400B323CF /* AccessibilityFixes.m */,
 				49087C13295DF0490058075B /* hook.h */,
 				49087C26295DF1350058075B /* mach_exc.defs */,
 				BBCED895255BB65A00CA0701 /* NSObject+SaneKVO.h */,
@@ -2154,6 +2157,7 @@
 				BB28C7A426896B1F00BDC834 /* AppGroup.m in Sources */,
 				BBECF3BC26913F1600DEC937 /* AppDelegate.m in Sources */,
 				BB28C7A526896B1F00BDC834 /* UIApplication+OpenURL.m in Sources */,
+				497A08C12963401100B323CF /* AccessibilityFixes.m in Sources */,
 				BB28C7A626896B1F00BDC834 /* AboutViewController.m in Sources */,
 				BB28C7A726896B1F00BDC834 /* UIViewController+Extras.m in Sources */,
 				BB28C7A826896B1F00BDC834 /* NSObject+SaneKVO.m in Sources */,

--- a/iSH.xcodeproj/project.pbxproj
+++ b/iSH.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		49302D8E277669D300C9885A /* ish.c in Sources */ = {isa = PBXBuildFile; fileRef = 49302D8D277669D300C9885A /* ish.c */; };
 		496C7AB227CC697E005D7613 /* Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = 491C4C1E27C8FB65008B1DFA /* Theme.m */; };
 		496C7AB327CC734D005D7613 /* ThemesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 491C4C1627C8F84A008B1DFA /* ThemesViewController.m */; };
+		497A08BF29633FF400B323CF /* mach_exc.defs in Sources */ = {isa = PBXBuildFile; fileRef = 49087C26295DF1350058075B /* mach_exc.defs */; settings = {ATTRIBUTES = (Server, ); }; };
+		497A08C029633FFA00B323CF /* hook.c in Sources */ = {isa = PBXBuildFile; fileRef = 49087C14295DF0490058075B /* hook.c */; };
 		497F6CF5254E5EA500C82F46 /* float80-test.c in Sources */ = {isa = PBXBuildFile; fileRef = 497F6C5A254E5C7E00C82F46 /* float80-test.c */; };
 		497F6CF6254E5EA500C82F46 /* float80.c in Sources */ = {isa = PBXBuildFile; fileRef = 497F6C66254E5C7F00C82F46 /* float80.c */; };
 		497F6CF7254E5EA500C82F46 /* fpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 497F6C5D254E5C7E00C82F46 /* fpu.c */; };
@@ -238,6 +240,22 @@
 		BBFB55662158644C00DFE6DE /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = BBFB55652158644C00DFE6DE /* libresolv.tbd */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXBuildRule section */
+		497A08BE29633FC100B323CF /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			fileType = sourcecode.mig;
+			inputFiles = (
+			);
+			isEditable = 1;
+			outputFiles = (
+				"$(DERIVED_FILE_DIR)/mach_excServer.h",
+				"$(DERIVED_FILE_DIR)/mach_excServer.c",
+			);
+			script = "set -x\n\nunset IPHONEOS_DEPLOYMENT_TARGET\n\nsdk=\"$(dirname \"$SCRIPT_INPUT_FILE\")/../../../\"\ncd \"$DERIVED_FILE_DIR\"\nmig -sheader \"$DERIVED_FILE_DIR/mach_excServer.h\" -server \"$DERIVED_FILE_DIR/mach_excServer.c\" -Wno-incompatible-sysroot -isysroot \"$sdk\" \"$SCRIPT_INPUT_FILE\"\n";
+		};
+/* End PBXBuildRule section */
+
 /* Begin PBXContainerItemProxy section */
 		497F6D5A254E609000C82F46 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -397,6 +415,9 @@
 /* Begin PBXFileReference section */
 		408A2639236440F8008A4E81 /* iOSFS.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iOSFS.m; sourceTree = "<group>"; };
 		408A263B23644102008A4E81 /* iOSFS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iOSFS.h; sourceTree = "<group>"; };
+		49087C13295DF0490058075B /* hook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = hook.h; sourceTree = "<group>"; };
+		49087C14295DF0490058075B /* hook.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = hook.c; sourceTree = "<group>"; };
+		49087C26295DF1350058075B /* mach_exc.defs */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.mig; name = mach_exc.defs; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/mach/mach_exc.defs; sourceTree = DEVELOPER_DIR; };
 		491B31E42883BF22008EEFB0 /* ThemeViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThemeViewController.h; sourceTree = "<group>"; };
 		491B31E52883BF22008EEFB0 /* ThemeViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ThemeViewController.m; sourceTree = "<group>"; };
 		491C4C1527C8F84A008B1DFA /* ThemesViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThemesViewController.h; sourceTree = "<group>"; };
@@ -1257,14 +1278,17 @@
 				BB9C7B84240A240E00F5D4F0 /* AppGroup.m */,
 				BB455E0F1FB37F6600AFB48B /* DelayedUITask.h */,
 				BB455E101FB37F6600AFB48B /* DelayedUITask.m */,
-				BBFB556F21586C4800DFE6DE /* UIViewController+Extras.h */,
-				BBFB557021586C4800DFE6DE /* UIViewController+Extras.m */,
-				BBFB557A215878C600DFE6DE /* UIApplication+OpenURL.h */,
-				BBFB557B215878C600DFE6DE /* UIApplication+OpenURL.m */,
+				49087C14295DF0490058075B /* hook.c */,
+				49087C13295DF0490058075B /* hook.h */,
+				49087C26295DF1350058075B /* mach_exc.defs */,
 				BBCED895255BB65A00CA0701 /* NSObject+SaneKVO.h */,
 				BBCED896255BB65A00CA0701 /* NSObject+SaneKVO.m */,
 				BB149E7E256DC97C00F57815 /* PassthroughView.h */,
 				BB149E7F256DC97C00F57815 /* PassthroughView.m */,
+				BBFB557A215878C600DFE6DE /* UIApplication+OpenURL.h */,
+				BBFB557B215878C600DFE6DE /* UIApplication+OpenURL.m */,
+				BBFB556F21586C4800DFE6DE /* UIViewController+Extras.h */,
+				BBFB557021586C4800DFE6DE /* UIViewController+Extras.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -1510,6 +1534,7 @@
 				BBEF191A26806364001225BD /* Sources */,
 			);
 			buildRules = (
+				497A08BE29633FC100B323CF /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
@@ -2112,8 +2137,10 @@
 				BBC3863F276817AD00CC8C2E /* CurrentRoot.m in Sources */,
 				BB28C79626896B1F00BDC834 /* ProgressReportViewController.m in Sources */,
 				BB28C79726896B1F00BDC834 /* TerminalView.m in Sources */,
+				497A08BF29633FF400B323CF /* mach_exc.defs in Sources */,
 				BB28C79826896B1F00BDC834 /* ScrollbarView.m in Sources */,
 				BB28C79926896B1F00BDC834 /* DelayedUITask.m in Sources */,
+				497A08C029633FFA00B323CF /* hook.c in Sources */,
 				BB28C7BF2689799800BDC834 /* Roots.m in Sources */,
 				BB28C79A26896B1F00BDC834 /* Terminal.m in Sources */,
 				BB28C79B26896B1F00BDC834 /* FontPickerViewController.m in Sources */,


### PR DESCRIPTION
This is a workaround for https://bugs.webkit.org/show_bug.cgi?id=249976, which should fix #1937.

There's a couple of things going on here that are probably worth noting:

* We rely on some things from the macOS SDK that happens to not be copied over the the iPhone one.
	* These are part of the platform ABI. In once case we use mig but could drop it in the future and use the generated files directly, if it becomes necessary. In another case use use a function from a header that Apple seems to have forgotten to include in the SDK. We can just ask for them to include it, and even if it goes away it isn't critical to anything.
* We need to parse the shared cache for symbols.
	* For space reasons Apple removes symbols from the address space that aren't exported. We need to read them out again from the file on disk. This file has a format that is subject to change. So far it has never changed in this way (I checked a decade). If it does this would break Apple's tooling, so there's a magic header that they check against to see if they know how to handle the file. We can check against this too.
* We need to set hardware breakpoints.
	* This is all API from the iPhone SDK, and it's used by the open-source LLDB. It's unusual to use it from current process, but ultimately all the function calls take a task and nothing is stopping us from offering up our own.
* We need to install a Mach exception handler.
	* This is API and pretty standard for crash reporting code, so it shouldn't break ever. One thing that has changed recently is that the guarded task ports mitigation makes it difficult to forward exceptions that we don't handle ourselves, which is useful when something else installs a handler at the thread/task level such as a debugger. If you have VoiceOver enabled and need the debugger to work it's not all that hard to disable the exception server. (I could also add code to do this automatically, but let's do that if it becomes a problem.)
* This entire thing is insane.
	* Yes but I've been unable to find another solution. Bugs have been filed and we'll continue to engage with Apple to see if we can improve our options. The code we are patching is not really something we should be touching, but I've put significant effort into finding the most specific API we can hook, making sure we immediately bail if anything seems to be going wrong, and only activate this code path on devices running new versions of iOS with VoiceOver enabled. Since those users already cannot really use iSH, this should be an improvement for them.