### PR TITLE
Encode exceptions into the crash log

### DIFF
--- a/app/AppDelegate.m
+++ b/app/AppDelegate.m
@@ -13,6 +13,7 @@
 #import "AppDelegate.h"
 #import "AppGroup.h"
 #import "CurrentRoot.h"
+#import "ExceptionExfiltrator.h"
 #import "iOSFS.h"
 #import "SceneDelegate.h"
 #import "PasteboardDevice.h"
@@ -55,12 +56,9 @@ static void ios_handle_exit(struct task *task, int code) {
     });
 }
 
-// Put the abort message in the thread name so it gets included in the crash dump
 static void ios_handle_die(const char *msg) {
-    char name[17];
-    pthread_getname_np(pthread_self(), name, sizeof(name));
-    NSString *newName = [NSString stringWithFormat:@"%s died: %s", name, msg];
-    pthread_setname_np(newName.UTF8String);
+    NSString *message = [NSString stringWithFormat:@"%s: %s", __func__, msg];
+    iSHExceptionHandler([[NSException alloc] initWithName:NSGenericException reason:message userInfo:nil]);
 }
 #elif ISH_LINUX
 void ReportPanic(const char *message) {

--- a/app/ExceptionExfiltrator.h
+++ b/app/ExceptionExfiltrator.h
@@ -1,0 +1,15 @@
+//
+//  ExceptionExfiltrator.h
+//  iSH
+//
+//  Created by Saagar Jha on 5/5/23.
+//
+
+#ifndef ExceptionExfiltrator_h
+#define ExceptionExfiltrator_h
+
+#import <Foundation/Foundation.h>
+
+void iSHExceptionHandler(NSException *exception);
+
+#endif /* ExceptionExfiltrator_h */

--- a/app/ExceptionExfiltrator.m
+++ b/app/ExceptionExfiltrator.m
@@ -1,0 +1,290 @@
+//
+//  ExceptionExfiltrator.m
+//  libiSHApp
+//
+//  Created by Saagar Jha on 5/5/23.
+//
+
+#import "ExceptionExfiltrator.h"
+#import <Foundation/Foundation.h>
+#import <execinfo.h>
+#import <pthread.h>
+
+#define f(name, character)         \
+	__asm__("\" " name "\": nop"); \
+	void ish_exception_exfiltrate_##character(void) __asm__(" " name)
+
+f("unprintable", unprintable);
+
+f(" ", space);
+f("!", exclamation_mark);
+f("quotation_mark", quotation_mark);
+f("#", number_sign);
+f("$", dollar_sign);
+f("%", percent_sign);
+f("&", ampersand);
+f("'", apostrophe);
+f("(", left_parenthesis);
+f(")", right_parenthesis);
+f("*", asterisk);
+f("+", plus_sign);
+f(",", comma);
+f("-", hyphen_minus);
+f(".", full_stop);
+f("/", solidus);
+f("0", 0);
+f("1", 1);
+f("2", 2);
+f("3", 3);
+f("4", 4);
+f("5", 5);
+f("6", 6);
+f("7", 7);
+f("8", 8);
+f("9", 9);
+f(":", colon);
+f(";", semicolon);
+f("<", less_than_sign);
+f("=", equals_sign);
+f(">", greater_than_sign);
+f("?", question_mark);
+f("@", commercial_at);
+f("A", A);
+f("B", B);
+f("C", C);
+f("D", D);
+f("E", E);
+f("F", F);
+f("G", G);
+f("H", H);
+f("I", I);
+f("J", J);
+f("K", K);
+f("L", L);
+f("M", M);
+f("N", N);
+f("O", O);
+f("P", P);
+f("Q", Q);
+f("R", R);
+f("S", S);
+f("T", T);
+f("U", U);
+f("V", V);
+f("W", W);
+f("X", X);
+f("Y", Y);
+f("Z", Z);
+f("[", left_square_bracket);
+f("reverse_solidus", reverse_solidus);
+f("]", right_square_bracket);
+f("^", circumflex_accent);
+f("_", low_line);
+f("`", grave_accent);
+f("a", a);
+f("b", b);
+f("c", c);
+f("d", d);
+f("e", e);
+f("f", f);
+f("g", g);
+f("h", h);
+f("i", i);
+f("j", j);
+f("k", k);
+f("l", l);
+f("m", m);
+f("n", n);
+f("o", o);
+f("p", p);
+f("q", q);
+f("r", r);
+f("s", s);
+f("t", t);
+f("u", u);
+f("v", v);
+f("w", w);
+f("x", x);
+f("y", y);
+f("z", z);
+f("{", left_curly_bracket);
+f("|", vertical_line);
+f("}", right_curly_bracket);
+f("~", tilde);
+
+#undef f
+
+#define f(character, name) [character] = ish_exception_exfiltrate_##name
+
+static void (*character2function[256])(void) = {
+    f(' ', space),
+    f('!', exclamation_mark),
+    f('"', quotation_mark),
+    f('#', number_sign),
+    f('$', dollar_sign),
+    f('%', percent_sign),
+    f('&', ampersand),
+    f('\'', apostrophe),
+    f('(', left_parenthesis),
+    f(')', right_parenthesis),
+    f('*', asterisk),
+    f('+', plus_sign),
+    f(',', comma),
+    f('-', hyphen_minus),
+    f('.', full_stop),
+    f('/', solidus),
+    f('0', 0),
+    f('1', 1),
+    f('2', 2),
+    f('3', 3),
+    f('4', 4),
+    f('5', 5),
+    f('6', 6),
+    f('7', 7),
+    f('8', 8),
+    f('9', 9),
+    f(':', colon),
+    f(';', semicolon),
+    f('<', less_than_sign),
+    f('=', equals_sign),
+    f('>', greater_than_sign),
+    f('?', question_mark),
+    f('@', commercial_at),
+    f('A', A),
+    f('B', B),
+    f('C', C),
+    f('D', D),
+    f('E', E),
+    f('F', F),
+    f('G', G),
+    f('H', H),
+    f('I', I),
+    f('J', J),
+    f('K', K),
+    f('L', L),
+    f('M', M),
+    f('N', N),
+    f('O', O),
+    f('P', P),
+    f('Q', Q),
+    f('R', R),
+    f('S', S),
+    f('T', T),
+    f('U', U),
+    f('V', V),
+    f('W', W),
+    f('X', X),
+    f('Y', Y),
+    f('Z', Z),
+    f('[', left_square_bracket),
+    f('\\', reverse_solidus),
+    f(']', right_square_bracket),
+    f('^', circumflex_accent),
+    f('_', low_line),
+    f('`', grave_accent),
+    f('a', a),
+    f('b', b),
+    f('c', c),
+    f('d', d),
+    f('e', e),
+    f('f', f),
+    f('g', g),
+    f('h', h),
+    f('i', i),
+    f('j', j),
+    f('k', k),
+    f('l', l),
+    f('m', m),
+    f('n', n),
+    f('o', o),
+    f('p', p),
+    f('q', q),
+    f('r', r),
+    f('s', s),
+    f('t', t),
+    f('u', u),
+    f('v', v),
+    f('w', w),
+    f('x', x),
+    f('y', y),
+    f('z', z),
+    f('{', left_curly_bracket),
+    f('|', vertical_line),
+    f('}', right_curly_bracket),
+    f('~', tilde),
+};
+
+#undef f
+
+void __ish_exception_exfiltrate_NAME__(void) {
+	__asm__("nop");
+}
+
+void __ish_exception_exfiltrate_REASON__(void) {
+	__asm__("nop");
+}
+
+void __ish_exception_exfiltrate_BACKTRACE__(void) {
+	__asm__("nop");
+}
+
+static void (*function_for_character(unichar character))(void) {
+	return character < sizeof(character2function) / sizeof(*character2function) ? (character2function[character] ? character2function[character] : ish_exception_exfiltrate_unprintable) : ish_exception_exfiltrate_unprintable;
+}
+
+static void *address_for_function(void (*function)(void)) {
+	return (void *)((uintptr_t)function + 1);
+}
+
+struct frame {
+	void *next;
+	void *address;
+};
+
+static void *__ish_exception_exfiltrate_THREAD__(void *frames) {
+	*(void **)__builtin_frame_address(0) = frames;
+	__builtin_trap();
+}
+
+void iSHExceptionHandler(NSException *exception) {
+	NSArray<NSNumber *> *backtrace = exception.callStackReturnAddresses;
+	NSString *name = exception.name;
+	NSString *reason = exception.reason;
+	size_t size =
+	    backtrace.count + /* backtrace frames */
+	    1 +               /* __ish_exception_exfiltrate_BACKTRACE__ */
+	    name.length +     /* name */
+	    1 +               /* __ish_exception_exfiltrate__NAME__ */
+	    reason.length +   /* reason */
+	    1;                /* __ish_exception_exfiltrate__REASON__ */
+	struct frame *frames = malloc(sizeof(struct frame) * size);
+	frames[0].next = NULL;
+
+	for (size_t i = 1; i < size; ++i) {
+		frames[i].next = frames + i - 1;
+	}
+
+	size_t index = 0;
+
+	for (NSNumber *address in backtrace.reverseObjectEnumerator) {
+		frames[index++].address = address.pointerValue;
+	}
+
+	frames[index++].address = address_for_function(__ish_exception_exfiltrate_BACKTRACE__);
+
+	for (NSUInteger i = 0; i < reason.length; ++i, ++index) {
+		frames[index].address = address_for_function(function_for_character([reason characterAtIndex:reason.length - i - 1]));
+	}
+
+	frames[index++].address = address_for_function(__ish_exception_exfiltrate_REASON__);
+
+	for (NSUInteger i = 0; i < name.length; ++i, ++index) {
+		frames[index].address = address_for_function(function_for_character([name characterAtIndex:name.length - i - 1]));
+	}
+
+	frames[index++].address = address_for_function(__ish_exception_exfiltrate_NAME__);
+
+	pthread_t thread;
+	pthread_create(&thread, NULL, __ish_exception_exfiltrate_THREAD__, frames + size - 1);
+	pthread_join(thread, NULL);
+}

--- a/app/main.m
+++ b/app/main.m
@@ -7,8 +7,10 @@
 
 #import <UIKit/UIKit.h>
 #import "AppDelegate.h"
+#import "ExceptionExfiltrator.h"
 
 int main(int argc, char * argv[]) {
+    NSSetUncaughtExceptionHandler(iSHExceptionHandler);
     @autoreleasepool {
         return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
     }

--- a/iSH.xcodeproj/project.pbxproj
+++ b/iSH.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		497F6D3D254E5EA600C82F46 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = BB7D93822087C2890008DA78 /* main.c */; };
 		497F6D5C254E609700C82F46 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = BB7D93822087C2890008DA78 /* main.c */; };
 		497F6D87254E62E100C82F46 /* libish.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB13F7DC200AD81D003D1C4D /* libish.a */; };
+		49FF844B2A06249F00850B7A /* ExceptionExfiltrator.m in Sources */ = {isa = PBXBuildFile; fileRef = 49FF844A2A06249F00850B7A /* ExceptionExfiltrator.m */; };
 		BB0F552E239F8A790032A2A1 /* Icons.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB0F552D239F8A790032A2A1 /* Icons.plist */; };
 		BB10E5C9248DBAAC009C7A74 /* libarchive.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB10E5C8248DBAA1009C7A74 /* libarchive.a */; };
 		BB10E5D0248DC21D009C7A74 /* Roots.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BB10E5CF248DC21D009C7A74 /* Roots.storyboard */; };
@@ -577,6 +578,8 @@
 		497F6CD3254E5CC800C82F46 /* bits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bits.h; sourceTree = "<group>"; };
 		497F6CE4254E5E4C00C82F46 /* MakeXcodeAutoCompleteWork */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = MakeXcodeAutoCompleteWork; sourceTree = BUILT_PRODUCTS_DIR; };
 		497F6D47254E605F00C82F46 /* ish */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = ish; sourceTree = BUILT_PRODUCTS_DIR; };
+		49FF844A2A06249F00850B7A /* ExceptionExfiltrator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExceptionExfiltrator.m; sourceTree = "<group>"; };
+		49FF844C2A0624AF00850B7A /* ExceptionExfiltrator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExceptionExfiltrator.h; sourceTree = "<group>"; };
 		650B337222EA235C00B4C03E /* PasteboardDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PasteboardDevice.h; sourceTree = "<group>"; };
 		650B337322EA235C00B4C03E /* PasteboardDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PasteboardDevice.m; sourceTree = "<group>"; };
 		8632A7BD219A59FB00F02325 /* UserPreferences.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserPreferences.h; sourceTree = "<group>"; };
@@ -1279,12 +1282,14 @@
 		BBFB557221586C6600DFE6DE /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				497A08BC2961168400B323CF /* AccessibilityFixes.m */,
 				BB9C7B86240A29DE00F5D4F0 /* AppGroup.h */,
 				BB9C7B84240A240E00F5D4F0 /* AppGroup.m */,
 				BB455E0F1FB37F6600AFB48B /* DelayedUITask.h */,
 				BB455E101FB37F6600AFB48B /* DelayedUITask.m */,
+				49FF844C2A0624AF00850B7A /* ExceptionExfiltrator.h */,
+				49FF844A2A06249F00850B7A /* ExceptionExfiltrator.m */,
 				49087C14295DF0490058075B /* hook.c */,
-				497A08BC2961168400B323CF /* AccessibilityFixes.m */,
 				49087C13295DF0490058075B /* hook.h */,
 				49087C26295DF1350058075B /* mach_exc.defs */,
 				BBCED895255BB65A00CA0701 /* NSObject+SaneKVO.h */,
@@ -2161,6 +2166,7 @@
 				BB28C7A426896B1F00BDC834 /* AppGroup.m in Sources */,
 				BBECF3BC26913F1600DEC937 /* AppDelegate.m in Sources */,
 				BB28C7A526896B1F00BDC834 /* UIApplication+OpenURL.m in Sources */,
+				49FF844B2A06249F00850B7A /* ExceptionExfiltrator.m in Sources */,
 				497A08C12963401100B323CF /* AccessibilityFixes.m in Sources */,
 				BB28C7A626896B1F00BDC834 /* AboutViewController.m in Sources */,
 				BB28C7A726896B1F00BDC834 /* UIViewController+Extras.m in Sources */,


### PR DESCRIPTION
Apple's crash reports don't contain exception name/reason information. We can get this back in a roundabout way by constructing a fake backtrace and encoding the exception information into that.