### PR TITLE
Quickfix x86 builds

### DIFF
--- a/iSH.xcodeproj/project.pbxproj
+++ b/iSH.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		0FC2383C2991FBA6004C09EC /* mmx.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FC2383B2991FB82004C09EC /* mmx.c */; };
+		1D409DEF2A2D4A6800E08219 /* libfakefs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB21A16F2689041500BD19B4 /* libfakefs.a */; };
 		491B31E62883BF22008EEFB0 /* ThemeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 491B31E52883BF22008EEFB0 /* ThemeViewController.m */; };
 		49302D8E277669D300C9885A /* ish.c in Sources */ = {isa = PBXBuildFile; fileRef = 49302D8D277669D300C9885A /* ish.c */; };
 		496C7AB227CC697E005D7613 /* Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = 491C4C1E27C8FB65008B1DFA /* Theme.m */; };
@@ -746,6 +747,7 @@
 			files = (
 				497F6D87254E62E100C82F46 /* libish.a in Frameworks */,
 				BBFB2C7E259026C200545EAB /* libish_emu.a in Frameworks */,
+				1D409DEF2A2D4A6800E08219 /* libfakefs.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/xcode-meson.sh
+++ b/xcode-meson.sh
@@ -11,9 +11,18 @@ if [[ $? -ne 0 ]]; then
     export CC_FOR_BUILD="env -u SDKROOT -u IPHONEOS_DEPLOYMENT_TARGET xcrun clang"
     export CC="$CC_FOR_BUILD" # compatibility with meson < 0.54.0
     crossfile=cross.txt
+
+    # We need to reset archs to compensate for problematic universal builds showing up
+    # for certain targets.
+    # NOTE for x86: arm64 needs to be set in EXCLUDED_ARCHS
+    if [[ "$ARCHS" == *"x86"* ]]; then
+        ARCHS="x86_64"
+    fi
+
     for arch in $ARCHS; do
         arch_args="'-arch', '$arch', $arch_args"
     done
+
     arch_args="${arch_args%%, }"
     meson_arch=${ARCHS%% *}
     case "$meson_arch" in


### PR DESCRIPTION
A small patch for the time being until the build environment gets rewritten. I attempted to have `EXCLUDED_ARCHS` set from the xcconfig, but it just wouldn't take and I'd still get issues when it'd try cross compiling the arm64 build. I've left a comment about that unless there's another way of getting the following line to work:

```xcconfig
EXCLUDED_ARCHS[sdk=macosx*][arch=x86_64] = arm64
```

This is all under the assumption that universal builds just won't make the cut for iSH.