### PR TITLE
fix tiocgpgrp for pty master

### DIFF
--- a/fs/tty.h
+++ b/fs/tty.h
@@ -66,7 +66,7 @@ struct termios_ {
 #define TCSETSF_ 0x5404
 #define TCFLSH_ 0x540b
 #define TIOCSCTTY_ 0x540e
-#define TIOCGPRGP_ 0x540f
+#define TIOCGPGRP_ 0x540f
 #define TIOCSPGRP_ 0x5410
 #define TIOCGWINSZ_ 0x5413
 #define TIOCSWINSZ_ 0x5414


### PR DESCRIPTION
I have made modifications to TIOCGPGRP for the pty master.

Currently, if the tty of the master is not set as the controlling terminal for the process group to which the current process belongs, it results in an error. However, the actual behavior in Linux is that when a file descriptor of the pty master is specified, it sets the process group ID of the controlling terminal to the corresponding slave when available. Therefore, for the pty master, I have made the modification to return the fg_group of the tty set as 'other.'

Furthermore, I have corrected the name from TIOCGPRGP, which seems to be a typo, to TIOCGPGRP.