### PR TITLE
fix locking pids_lock timing of do_exit

### DIFF
--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -49,6 +49,8 @@ noreturn void do_exit(int status) {
             futex_wake(clear_tid, 1);
     }
 
+    // the actual freeing needs pids_lock
+    lock(&pids_lock);
     // release all our resources
     mm_release(current->mm);
     current->mm = NULL;
@@ -67,8 +69,6 @@ noreturn void do_exit(int status) {
     struct rusage_ group_rusage = current->group->rusage;
     unlock(&current->group->lock);
 
-    // the actual freeing needs pids_lock
-    lock(&pids_lock);
     current->exiting = true;
     // release the sighand
     sighand_release(current->sighand);


### PR DESCRIPTION
I have corrected the timing of locking the pids_lock in the do_exit function to be before mm_release.

The reason for this fix is that there was a potential for invalid memory access when executing processes related to /proc/<pid>, specifically when memory for the struct task member is freed during the process (this issue occurred during the execution of tmux). Additionally, there was a problem where resources locked during operations on /proc/{pid} were being released in do_exit, leading to further issues, so I addressed and fixed that as well.