### PR TITLE
Fix bad timeout values in `pselect()` (which broke mosh)

### DIFF
--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -732,20 +732,6 @@ dword_t sys_flock(fd_t f, dword_t operation) {
     return fd->mount->fs->flock(fd, operation);
 }
 
-static struct timespec convert_timespec(struct timespec_ t) {
-    struct timespec ts;
-    ts.tv_sec = t.sec;
-    ts.tv_nsec = t.nsec;
-    return ts;
-}
-
-static struct timespec convert_timeval(struct timeval_ t) {
-    struct timespec ts;
-    ts.tv_sec = t.sec;
-    ts.tv_nsec = t.usec * 1000;
-    return ts;
-}
-
 static dword_t sys_utime_common(fd_t at_f, addr_t path_addr, struct timespec atime, struct timespec mtime, dword_t flags) {
     char path[MAX_PATH];
     if (path_addr != 0)

--- a/kernel/log.c
+++ b/kernel/log.c
@@ -3,8 +3,12 @@
 #include <stdarg.h>
 #include <string.h>
 #include <sys/uio.h>
+#include <syslog.h>
 #if LOG_HANDLER_NSLOG
 #include <CoreFoundation/CoreFoundation.h>
+#endif
+#if LOG_HANDLER_OS_LOG
+#include <os/log.h>
 #endif
 #include "kernel/calls.h"
 #include "util/sync.h"
@@ -141,6 +145,14 @@ static void log_line(const char *line) {
 static void log_line(const char *line) {
     extern void NSLog(CFStringRef msg, ...);
     NSLog(CFSTR("%s"), line);
+}
+#elif LOG_HANDLER_SYSLOG
+static void log_line(const char *line) {
+    syslog(LOG_DEBUG, "%s", line);
+}
+#elif LOG_HANDLER_OS_LOG
+static void log_line(const char *line) {
+    os_log_fault(OS_LOG_DEFAULT, "%s", line);
 }
 #endif
 

--- a/kernel/time.h
+++ b/kernel/time.h
@@ -29,6 +29,20 @@ static inline clock_t_ clock_from_timeval(struct timeval_ timeval) {
     return timeval.sec * 100 + timeval.usec / 10000;
 }
 
+static inline struct timespec convert_timespec(struct timespec_ t) {
+    struct timespec ts;
+    ts.tv_sec = t.sec;
+    ts.tv_nsec = t.nsec;
+    return ts;
+}
+
+static inline struct timespec convert_timeval(struct timeval_ t) {
+    struct timespec ts;
+    ts.tv_sec = t.sec;
+    ts.tv_nsec = t.usec * 1000;
+    return ts;
+}
+
 #define ITIMER_REAL_ 0
 #define ITIMER_VIRTUAL_ 1
 #define ITIMER_PROF_ 2

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -25,11 +25,14 @@ libarchive = dependency('libarchive', required: false)
 if not libarchive.found()
     # homebrew
     libarchive_lib = cc.find_library('archive', dirs: ['/usr/local/opt/libarchive/lib'], required: false)
-    if not libarchive_lib.found()
-        libarchive_lib = cc.find_library('archive', dirs: ['/opt/homebrew/opt/libarchive/lib'], required: false)
-    endif
     if libarchive_lib.found()
         libarchive = declare_dependency(dependencies: [libarchive_lib], include_directories: include_directories(['/usr/local/opt/libarchive/include']))
+    else
+        # Apple Silicon Homebrew
+        libarchive_lib = cc.find_library('archive', dirs: ['/opt/homebrew/opt/libarchive/lib'], required: false)
+        if libarchive_lib.found()
+            libarchive = declare_dependency(dependencies: [libarchive_lib], include_directories: include_directories(['/opt/homebrew/opt/libarchive/include']))
+        endif
     endif
 endif
 

--- a/xX_main_Xx.h
+++ b/xX_main_Xx.h
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <errno.h>
+#include <syslog.h>
 #include "kernel/init.h"
 #include "kernel/fs.h"
 #include "fs/devices.h"
@@ -66,6 +67,8 @@ static inline int xX_main_Xx(int argc, char *const argv[], const char *envp) {
 
         }
     }
+
+    openlog(argv[0], 0, LOG_USER);
 
     char root_realpath[MAX_PATH + 1] = "/";
     if (root != NULL && realpath(root, root_realpath) == NULL) {


### PR DESCRIPTION
`mosh` almost works, but it has weird unpredictable 1-30 second lag on text input that is quite incredibly annoying.

I ran this down to a fairly simple oversight:  `pselect()` takes a `timespec` for the timeout value, but that was getting passed unchanged to the iSH `select()` implementation which takes a `timeval`.

It looks like a fix was made for #711 earlier that sort of worked; this probably fixes the real underlying problem with Emacs.  That change clamped the excessively big nanosecond values to be +1 second, but Mosh was still badly affected.

This will probably clear up other mysterious lags in other applications.

There's a couple of other minor fixes I needed to get the CLI build working and logging, too.
