### PR TITLE
Add another very simple log destination-- fprintf to stderr

### DIFF
--- a/kernel/log.c
+++ b/kernel/log.c
@@ -154,6 +154,10 @@ static void log_line(const char *line) {
 static void log_line(const char *line) {
     os_log_fault(OS_LOG_DEFAULT, "%s", line);
 }
+#elif LOG_HANDLER_STDERR
+static void log_line(const char *line) {
+    fprintf(stderr, "%s\n", line);
+}
 #endif
 
 static void default_die_handler(const char *msg) {


### PR DESCRIPTION
CLI ish's emulated tty only writes to stdout, so we can write debug logs to stderr and redirect it.
