### PR TITLE
Fix pty close behavior, signals at exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Open the project in Xcode, open iSH.xcconfig, and change `ROOT_BUNDLE_IDENTIFIER
 
 To set up your environment, cd to the project and run `meson build` to create a build directory in `build`. Then cd to the build directory and run `ninja`.
 
-To set up a self-contained Alpine linux filesystem, download the Alpine minirootfs tarball for i386 from the [Alpine website](https://alpinelinux.org/downloads/) and run `./tools/fakefsify`, with the minirootfs tarball as the first argument and the name of the output directory as the second argument. Then you can run things inside the Alpine filesystem with `./ish -f alpine /bin/login -f root`, assuming the output directory is called `alpine`. If `tools/fakefsify` doesn't exist for you in your build directory, that might be because it couldn't find libarchive on your system (see above for ways to install it.)
+To set up a self-contained Alpine linux filesystem, download the Alpine minirootfs tarball for i386 from the [Alpine website](https://alpinelinux.org/downloads/) and run `./tools/fakefsify`, with the minirootfs tarball as the first argument and the name of the output directory as the second argument. Then you can run things inside the Alpine filesystem with `./ish -f alpine /bin/sh`, assuming the output directory is called `alpine`. If `tools/fakefsify` doesn't exist for you in your build directory, that might be because it couldn't find libarchive on your system (see above for ways to install it.)
 
 You can replace `ish` with `tools/ptraceomatic` to run the program in a real process and single step and compare the registers at each step. I use it for debugging. Requires 64-bit Linux 4.11 or later.
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -43,7 +43,7 @@ Xcode로 프로젝트를 열고, iSH.xcconfig 연 후에 `ROOT_BUNDLE_IDENTIFIER
 
 환경을 세팅하기 위해서는 프로젝트 디렉토리로 이동하고 `meson build`를 커맨드 라인에 입력하세요. 그 후 빌드 된 디렉토리로 cd 후 `ninja` 커맨드를 입력해 실행하세요.
 
-자체적으로 컨테이너 화 된 Alpine 리눅스 파일 시스템으로 실행하고 싶다면, [Alpine 웹사이트](https://alpinelinux.org/downloads/) 에서 i386을 위한 Alpine minirootfs(Mini Root Filesystem) tarball 을 다운로드 받고 `./tools/fakefsify`으로 실행하세요. 매개인자로 다운로드 받은 minirootfs tarball 파일을 입력하고 출력 받을 디렉토리의 이름을 두번째 인자로 입력하면 됩니다. 그 후에는 `./ish -f {출력받을 디렉토리 이름} /bin/login -f root` 명령어를 사용하여 Alpine 시스템 내에서 원하는 것을 실행할 수 있습니다. 만약 `tools/fakefsify` 가 빌드 디렉토리에 존재하지 않는다면, libarchive를 찾을 수 없어서 그런 것일 수 있습니다. 위를 참고하여 시스템에 설치하는 방법을 참고해주세요.
+자체적으로 컨테이너 화 된 Alpine 리눅스 파일 시스템으로 실행하고 싶다면, [Alpine 웹사이트](https://alpinelinux.org/downloads/) 에서 i386을 위한 Alpine minirootfs(Mini Root Filesystem) tarball 을 다운로드 받고 `./tools/fakefsify`으로 실행하세요. 매개인자로 다운로드 받은 minirootfs tarball 파일을 입력하고 출력 받을 디렉토리의 이름을 두번째 인자로 입력하면 됩니다. 그 후에는 `./ish -f {출력받을 디렉토리 이름} /bin/sh` 명령어를 사용하여 Alpine 시스템 내에서 원하는 것을 실행할 수 있습니다. 만약 `tools/fakefsify` 가 빌드 디렉토리에 존재하지 않는다면, libarchive를 찾을 수 없어서 그런 것일 수 있습니다. 위를 참고하여 시스템에 설치하는 방법을 참고해주세요.
 
 실제 프로세스로 프로그램을 실행하고 각 단계의 레지스터를 비교하기 위해서 `ish`를 `tools/ptraceomatic`로 바꿔 실행할 수 있습니다. 디버깅을 위해 저는 사용합니다. 64-bit Linux 4.11 이후 버전이 필요합니다.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -40,7 +40,7 @@ iSH 是一个运行在 iOS 上的 Linux shell。本项目使用了 x86 用户模
 
 在项目目录中运行命令 `meson build`，之后 `build` 目录会被创建。进入到 `build` 目录并运行命令 `ninja`。
 
-为了建立一个自有的 Alpine linux 文件系统，请从 [Alpine 网站](https://alpinelinux.org/downloads/) 下载 `Alpine minirotfs tarball for i386` 并运行 `tools/fakefsify` 。将 minirotfs tarball 指定为第一个参数，将输出目录的名称（如`alpine`）指定为第二个参数，即 `tools/fakefsify $MinirotfsTarballFilename alpine` 然后在 Alpine 文件系统中运行 `/ish -f alpine/bin/login -f root`。如果 `build` 目录下找不到 `tools/fakefsify`，可能是系统上找不到 `libarchive` 的依赖（请参照前面的章节进行安装）。
+为了建立一个自有的 Alpine linux 文件系统，请从 [Alpine 网站](https://alpinelinux.org/downloads/) 下载 `Alpine minirotfs tarball for i386` 并运行 `tools/fakefsify` 。将 minirotfs tarball 指定为第一个参数，将输出目录的名称（如`alpine`）指定为第二个参数，即 `tools/fakefsify $MinirotfsTarballFilename alpine` 然后在 Alpine 文件系统中运行 `/ish -f alpine/bin/sh`。如果 `build` 目录下找不到 `tools/fakefsify`，可能是系统上找不到 `libarchive` 的依赖（请参照前面的章节进行安装）。
 
 除了可以使用 `ish`，你也可以使用 `tools/ptraceomatic` 替代它，以便在某个真实进程中单步比较寄存器。我通常使用它来进行调试（需要 64 位 Linux 4.11 或更高版本）。
 

--- a/fs/tty.c
+++ b/fs/tty.c
@@ -672,7 +672,7 @@ static int tiocgpgrp(struct tty *tty, pid_t_ *fg_group) {
         lock(&slave->lock);
     }
 
-    if (tty == slave && !tty_is_current(slave) || slave->fg_group == 0) {
+    if (tty == slave && (!tty_is_current(slave) || slave->fg_group == 0)) {
         err = _ENOTTY;
         goto error_no_ctrl_tty;
     }

--- a/fs/tty.h
+++ b/fs/tty.h
@@ -93,6 +93,7 @@ struct tty_driver {
 struct tty_driver_ops {
     int (*init)(struct tty *tty);
     int (*open)(struct tty *tty);
+    int (*close)(struct tty *tty);
     int (*write)(struct tty *tty, const void *buf, size_t len, bool blocking);
     int (*ioctl)(struct tty *tty, int cmd, void *arg);
     void (*cleanup)(struct tty *tty);

--- a/ish-lldb.lldb
+++ b/ish-lldb.lldb
@@ -1,0 +1,1 @@
+process handle -n 0 -p 1 -s 0 SIGUSR1 SIGTTIN SIGPIPE

--- a/kernel/log.c
+++ b/kernel/log.c
@@ -154,6 +154,10 @@ static void log_line(const char *line) {
 static void log_line(const char *line) {
     os_log_fault(OS_LOG_DEFAULT, "%s", line);
 }
+#elif LOG_HANDLER_STDERR
+static void log_line(const char *line) {
+    fprintf(stderr, "%s\n", line);
+}
 #endif
 
 static void default_die_handler(const char *msg) {


### PR DESCRIPTION
There's two big things in here.

When running `mosh --local 0`, I found that `mosh-server` would never terminate on iSH.  It was waiting for the master side of its pty to close.  Most applications that use ptys use other methods to detect child termination, but `mosh-server` expects that the pty master will act as a closed file after the last program on the pty slave exits-- any waiting reads should return immediately with 0 bytes, and further read calls should return EOF.  This is what pipes and sockets do, of course.  iSH master ptys stayed in the read call forever, even though the pty slave was gone.  This fixes that and ends up better separating generic tty code from pty slaves from pty masters too.

`dtach` behaves similarly and the fix helps it too.

After I fixed that, I found that CLI ish would exit with signal 9 when `mosh-server` exited.  This is because the README recommends to use `/bin/login` as the starting process.  Unfortunately, that means `/bin/login` runs as pid 1 (init) and is notified when orphaned processes terminate (which `mosh-server` is, because it double forks).  `/bin/login` has never been intended as a process group leader or init process, it expects to start and `wait()` for exactly 1 child, usually an interactive shell.

But running `ish -f alpine /bin/sh` didn't work correctly either, when the initial shell exited iSH would exit on signal 9. (Or something, this was a couple of months ago and I'm forgetting details.  Maybe it was still when `mosh-server` exited, or when a subshell exited.)  That turned out to be a nasty problem with `halt_system()`.  This code runs when pid 1 exits.  This code uses `pthread_kill()` to send a SIGKILL to threads running the emulated process group to kill off emulated processes in iSH.  Uhh... that doesn't work.  SIGKILL always nukes the entire process, not a single thread.

After I changed that code to do a more kernel-like thing of using `deliver_signal()` to send first SIGTERM, then SIGKILL, and then finally `pthread_kill()` with SIGTERM, iSH behaves a lot better about emulated process termination, and exits cleanly (rather than with SIGKILL) when pid 1 terminates.

I changed the README to tell people to use `/bin/sh` as the starting process for CLI ish, because it can work as init/pid 1 and ignores termination of orphaned processes.  iSH.app should probably change to do the same.

I've not been able to build iSH.app in XCode, so all of this is untested there, but I believe it will help there-- the app won't quit when the initial shell exits.

After fixing this and then finding/fixing the procfs problem in #2386, I ran into yet another bug in iSH, I forget what it was.  At that point I gave up chasing bugs in iSH.
