### PR TITLE
Fix reuse of pty slave devices

### DIFF
--- a/fs/pty.c
+++ b/fs/pty.c
@@ -66,6 +66,12 @@ static int pty_slave_open(struct tty *tty) {
         return _EIO;
     if (tty->pty.locked)
         return _EIO;
+    // If userland's reference count on the pty slave is now 1, clear
+    // hang_up on the pty master.  But the session leader may have a
+    // reference, and the pty master always has a reference.
+    if (tty->refcount - 1 == (tty->session ? 2 : 1)) {
+        tty->pty.other->hung_up = false;
+    }
     return 0;
 }
 

--- a/fs/tty.c
+++ b/fs/tty.c
@@ -446,6 +446,7 @@ static ssize_t tty_read(struct fd *fd, void *buf, size_t bufsize) {
     lock(&tty->lock);
     if (tty->hung_up || pty_is_half_closed_master(tty)) {
         unlock(&pids_lock);
+        err = -1;
         goto error;
     }
 

--- a/meson.build
+++ b/meson.build
@@ -181,8 +181,8 @@ endif
 
 subdir('tools')
 
-gdb_scripts = ['ish-gdb.gdb']
-foreach script : gdb_scripts
+debugger_scripts = ['ish-gdb.gdb', 'ish-lldb.lldb']
+foreach script : debugger_scripts
     custom_target(script,
         output: script, input: script,
         command: ['ln', '-sf', '@INPUT@', '@OUTPUT@'],


### PR DESCRIPTION
This should fix the problem brought up by @francoisvignon in my original work on #2387.   At the time I wrote that I hadn't even thought about pty masters allowing serial reuse of the pty slave, and so it worked more like physical serial devices, where you don't want them to work after the modem hangs up.

This is definitely one of those less well documented and supported bits of functionality in ptys (there are many).  But it seems like a good idea to support this because Linux does.
