### PR TITLE
Promote hostname override to a friendly preference 

### DIFF
--- a/app/AppDelegate.m
+++ b/app/AppDelegate.m
@@ -284,7 +284,10 @@ void NetworkReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
     proc_ish_version = strdup(ishVersion.UTF8String);
     // this defaults key is set when taking app store screenshots
     extern const char *uname_hostname_override;
-    NSString *hostnameOverride = [NSUserDefaults.standardUserDefaults stringForKey:@"hostnameOverride"];
+    NSString *hostnameOverride = UserPreferences.shared._hostnameOverride;
+    if (@available(iOS 16.0, *)) { // Hostname obfuscation is in effect
+        hostnameOverride = hostnameOverride ? hostnameOverride : UserPreferences.shared.hostnameOverride;
+    }
     if (hostnameOverride) {
         uname_hostname_override = strdup(hostnameOverride.UTF8String);
     }

--- a/app/AppDelegate.m
+++ b/app/AppDelegate.m
@@ -286,7 +286,7 @@ void NetworkReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
     extern const char *uname_hostname_override;
     NSString *hostnameOverride = [NSUserDefaults.standardUserDefaults stringForKey:@"hostnameOverride"];
     if (hostnameOverride) {
-        uname_hostname_override = strdup(uname_hostname_override);
+        uname_hostname_override = strdup(hostnameOverride.UTF8String);
     }
 #endif
     

--- a/app/UserPreferences.h
+++ b/app/UserPreferences.h
@@ -69,6 +69,9 @@ extern NSString *const kThemeBackgroundColor;
 @property (readonly) UIStatusBarStyle statusBarStyle;
 @property NSArray<NSString *> *launchCommand;
 @property NSArray<NSString *> *bootCommand;
+@property NSString *hostnameOverride;
+// Same as above but returns nil if the user has never set the hostname
+@property (readonly) NSString *_hostnameOverride;
 
 + (instancetype)shared;
 
@@ -78,5 +81,6 @@ extern NSString *const kThemeBackgroundColor;
 
 extern NSString *const kPreferenceLaunchCommandKey;
 extern NSString *const kPreferenceBootCommandKey;
+extern NSString *const kHostnameOverrideKey;
 
 NS_ASSUME_NONNULL_END

--- a/app/UserPreferences.m
+++ b/app/UserPreferences.m
@@ -517,6 +517,7 @@ bool (*remove_user_default)(const char *name);
     return [*value isKindOfClass:NSNumber.class];
 }
 
+// MARK: colorScheme
 - (ColorScheme)colorScheme {
     return [_defaults integerForKey:kPreferenceColorSchemeKey];
 }

--- a/app/UserPreferences.m
+++ b/app/UserPreferences.m
@@ -26,6 +26,9 @@ static NSString *const kPreferenceCursorStyleKey = @"Cursor Style";
 static NSString *const kPreferenceBlinkCursorKey = @"Blink Cursor";
 NSString *const kPreferenceHideStatusBarKey = @"Status Bar";
 static NSString *const kPreferenceColorSchemeKey = @"Color Scheme";
+// This key has a different naming scheme because it's used in UI tests as a
+// CLI argument.
+NSString *const kHostnameOverrideKey = @"hostnameOverride";
 
 NSDictionary<NSString *, NSString *> *friendlyPreferenceMapping;
 NSDictionary<NSString *, NSString *> *friendlyPreferenceReverseMapping;
@@ -33,7 +36,9 @@ NSDictionary<NSString *, NSString *> *kvoProperties;
 
 static NSString *const kSystemMonospacedFontName = @"ui-monospace";
 
-@interface UserPreferences ()
+@interface UserPreferences () {
+    BOOL _hostnameIsOverridden;
+}
 - (void)updateTheme;
 @end
 
@@ -144,6 +149,7 @@ bool (*remove_user_default)(const char *name);
 
 - (instancetype)init {
     self = [super init];
+    self->_hostnameIsOverridden = !![NSUserDefaults.standardUserDefaults stringForKey:kHostnameOverrideKey];
     if (self) {
         _defaults = [NSUserDefaults standardUserDefaults];
         [_defaults registerDefaults:@{
@@ -161,6 +167,7 @@ bool (*remove_user_default)(const char *name);
             kPreferenceHideStatusBarKey: @(NO),
             kPreferenceColorSchemeKey: @(ColorSchemeMatchSystem),
             kPreferenceThemeKey: @"Default",
+            kHostnameOverrideKey: UIDevice.currentDevice.name,
         }];
         // https://webkit.org/blog/10247/new-webkit-features-in-safari-13-1/
         if (@available(iOS 13.4, *)) {
@@ -194,6 +201,7 @@ bool (*remove_user_default)(const char *name);
             @"hide_status_bar": kPreferenceHideStatusBarKey,
             @"color_scheme": kPreferenceColorSchemeKey,
             @"theme": kPreferenceThemeKey,
+            @"hostname_override": kHostnameOverrideKey,
         };
         NSMutableDictionary <NSString *, NSString *> *reverseMapping = [NSMutableDictionary new];
         for (NSString *key in friendlyPreferenceMapping) {
@@ -532,6 +540,23 @@ bool (*remove_user_default)(const char *name);
     }
     int _value = [(NSNumber *)(*value) intValue];
     return _value >= __ColorSchemeFirst && _value < __ColorSchemeLast;
+}
+
+// MARK: hostnameOverride
+- (NSString *)hostnameOverride {
+    return [_defaults stringForKey:kHostnameOverrideKey];
+}
+
+- (void)setHostnameOverride:(NSString *)hostnameOverride {
+    [_defaults setValue:hostnameOverride forKey:kHostnameOverrideKey];
+}
+
+- (BOOL)validateHostnameOverride:(id *)value error:(NSError **)error {
+    return [*value isKindOfClass:NSString.class];
+}
+
+- (NSString *)_hostnameOverride {
+    return _hostnameIsOverridden ? self.hostnameOverride : nil;
 }
 
 + (BOOL)systemThemeIsDark {


### PR DESCRIPTION
Users really hate that we put "localhost" in their prompt as a result of iOS 16 anti-fingerprinting obfuscating the device name. We already have a mechanism for overriding this that we use for App Store screenshots, so we might as well make it official and expose it for those that care.

The logic for what the actual uname hostname is as follows:

* If the user sets the preference, use that.
* On iOS <16, if the preference is unset, use what real uname returns.
* On iOS 16+, use UIDevice.name. This at least changes "localhost" to something like "iPad".