### PR TITLE
Make sure to take sqlite write locks upfront

### DIFF
--- a/app/FileProvider/FileProviderEnumerator.m
+++ b/app/FileProvider/FileProviderEnumerator.m
@@ -62,7 +62,7 @@
         if (strcmp(dirent->d_name, "..") == 0) {
             childIdent = _item.parentItemIdentifier;
         } else if (strcmp(dirent->d_name, ".") != 0) {
-            db_begin(&_item.mount->db);
+            db_begin_read(&_item.mount->db);
             inode_t inode = path_get_inode(&_item.mount->db, [path stringByAppendingFormat:@"/%@", [NSString stringWithUTF8String:dirent->d_name]].fileSystemRepresentation);
             db_commit(&_item.mount->db);
             if (inode == 0) {

--- a/app/FileProvider/FileProviderItem.m
+++ b/app/FileProvider/FileProviderItem.m
@@ -43,7 +43,7 @@
     if (self.isRoot) {
         fd = open(_mount->source, O_DIRECTORY | O_RDONLY);
     } else {
-        db_begin(&_mount->db);
+        db_begin_read(&_mount->db);
         sqlite3_stmt *stmt = _mount->db.stmt.path_from_inode;
         sqlite3_bind_int64(_mount->db.stmt.path_from_inode, 1, _identifier.longLongValue);
         while (db_exec(&_mount->db, stmt)) {
@@ -87,7 +87,7 @@
 
 - (struct ish_stat)ishStat {
     struct ish_stat stat = {};
-    db_begin(&_mount->db);
+    db_begin_read(&_mount->db);
     inode_t inode = _identifier.longLongValue;
     if ([_identifier isEqualToString:NSFileProviderRootContainerItemIdentifier])
         inode = path_get_inode(&_mount->db, "");
@@ -115,7 +115,7 @@
     NSString *parentPath = self.path.stringByDeletingLastPathComponent;
     if ([parentPath isEqualToString:@"/"])
         return NSFileProviderRootContainerItemIdentifier;
-    db_begin(&_mount->db);
+    db_begin_read(&_mount->db);
     inode_t parentInode = path_get_inode(&_mount->db, parentPath.UTF8String);
     db_commit(&_mount->db);
     assert(parentInode != 0);

--- a/fs/fake-db.h
+++ b/fs/fake-db.h
@@ -8,7 +8,8 @@
 struct fakefs_db {
     sqlite3 *db;
     struct {
-        sqlite3_stmt *begin;
+        sqlite3_stmt *begin_deferred;
+        sqlite3_stmt *begin_immediate;
         sqlite3_stmt *commit;
         sqlite3_stmt *rollback;
         sqlite3_stmt *path_get_inode;
@@ -29,7 +30,8 @@ struct fakefs_db {
 int fake_db_init(struct fakefs_db *fs, const char *db_path, int root_fd);
 int fake_db_deinit(struct fakefs_db *fs);
 
-void db_begin(struct fakefs_db *fs);
+void db_begin_read(struct fakefs_db *fs);
+void db_begin_write(struct fakefs_db *fs);
 void db_commit(struct fakefs_db *fs);
 void db_rollback(struct fakefs_db *fs);
 


### PR DESCRIPTION
Fun quirk of sqlite is that if you BEGIN DEFERRED and then do a read statement and then another process concurrently does a write and then the first process does a write statement on the same transaction, it will immediately return SQLITE_BUSY because it's impossible to do a write against a past version of the database. To fix this we need to use BEGIN IMMEDIATE to take a write lock upfront on any transaction that will need to write.