### PR TITLE
Always focus on the window when there is no selection

### DIFF
--- a/app/terminal/term.js
+++ b/app/terminal/term.js
@@ -90,7 +90,8 @@ term.scrollPort_.screen_.addEventListener('blur', (e) => {
 }, {capture: true});
 term.scrollPort_.screen_.addEventListener('mousedown', (e) => {
     // Taps while there is a selection should be left to the selection view
-    if (document.getSelection().rangeCount != 0) return;
+    if ((document.getSelection().rangeCount != 0) &&
+        (!document.getSelection().isCollapsed)) return;
     native.focus();
 });
 exports.setFocused = (focus) => {


### PR DESCRIPTION
Selection.rangeCount can return 1 when there is no selection, it is enough for a selection to have been present in the past or for the user to have clicked on the page.

See MDN: https://developer.mozilla.org/en-US/docs/Web/API/Selection/rangeCount

Use Selection.isCollapsed to be entirely sure there is a selection before ignoring the click.

This change fixes the issue ish-app/ish#2519, where focus to the terminal is lost and can not be regained, forcing the user to restart ish.

Tested on iPad Pro 13-inch (M4) with iPadOS 26 Beta 2 and Stage Manager.