### PR TITLE
ci: include release version in gh release name

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,6 +68,7 @@ lane :upload_build do
         groups: ["People"],
     )
 
+    version_number = get_version_number(xcodeproj: "iSH.xcodeproj")
     # uploading a build takes about 5 hours, so merge master back in if there have been any commits during that
     sh "git pull --no-rebase"
     push_to_git_remote
@@ -75,7 +76,7 @@ lane :upload_build do
         repository_name: "ish-app/ish",
         tag_name: tag,
         commitish: nil, # the tag better exist
-        name: "Build #{build_number}",
+        name: "#{version_number}-build#{build_number}",
         description: changelog,
         is_prerelease: true,
         upload_assets: ["iSH.ipa", "iSH.app.dSYM.zip"],


### PR DESCRIPTION
# Problem

Currently, the ish.app AltStore source is incompatible with AltStore 2.0 and SideStore (#2563). The previous attempt of trying to solve this on the ish.app project (https://github.com/ish-app/ish.app/pull/46) was hardcoding the version number, which was an area of feedback that couldn't be addressed, since a given GitHub release provides no indication of the app version that the build is for.

# Solution

This PR names each nightly release as a [semver](https://semver.org/) formatted version number of `<app version>-build<build number>`. No changes are made to the testflight upload or the actual artifact versions themselves.

With this change, we can then parse this information in the template to provide both the app version and build number to the appropriate [AltStore Source fields](https://faq.altstore.io/developers/make-a-source#app-versions). I've opened a PR over on the ish.app project to do that (https://github.com/ish-app/ish.app/pull/48).

Closes #2563 