### PR TITLE
Forward touch scroll events as terminal input

### DIFF
--- a/app/TerminalView.m
+++ b/app/TerminalView.m
@@ -272,9 +272,11 @@ static NSString *const HANDLERS[] = {@"syncFocus", @"focus", @"newScrollHeight",
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
     CGFloat newY = scrollView.contentOffset.y;
+    [self.terminal.webView evaluateJavaScript:[NSString stringWithFormat:@"exports.newScrollTop(%f)", newY] completionHandler:nil];
     CGFloat delta = newY - _prevScrollY;
     _prevScrollY = newY;
-    [self.terminal.webView evaluateJavaScript:[NSString stringWithFormat:@"exports.handleScroll(%f, %f)", newY, delta] completionHandler:nil];
+    if (delta != 0)
+        [self.terminal.webView evaluateJavaScript:[NSString stringWithFormat:@"exports.handleScrollDelta(%f)", delta] completionHandler:nil];
 }
 
 - (void)setKeyboardAppearance:(UIKeyboardAppearance)keyboardAppearance {

--- a/app/TerminalView.m
+++ b/app/TerminalView.m
@@ -31,7 +31,9 @@ struct rowcol {
 }
 @end
 
-@interface TerminalView ()
+@interface TerminalView () {
+    CGFloat _prevScrollY;
+}
 
 @property (nonatomic) NSMutableArray<UIKeyCommand *> *keyCommands;
 @property ScrollbarView *scrollbarView;
@@ -104,6 +106,7 @@ static NSString *const HANDLERS[] = {@"syncFocus", @"focus", @"newScrollHeight",
     }
 
     _terminal = terminal;
+    _prevScrollY = 0;
     [_terminal addObserver:self forKeyPath:@"loaded" options:NSKeyValueObservingOptionInitial context:nil];
     if (_terminal.loaded)
         [self installTerminalView];
@@ -268,7 +271,10 @@ static NSString *const HANDLERS[] = {@"syncFocus", @"focus", @"newScrollHeight",
 }
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    [self.terminal.webView evaluateJavaScript:[NSString stringWithFormat:@"exports.newScrollTop(%f)", scrollView.contentOffset.y] completionHandler:nil];
+    CGFloat newY = scrollView.contentOffset.y;
+    CGFloat delta = newY - _prevScrollY;
+    _prevScrollY = newY;
+    [self.terminal.webView evaluateJavaScript:[NSString stringWithFormat:@"exports.handleScroll(%f, %f)", newY, delta] completionHandler:nil];
 }
 
 - (void)setKeyboardAppearance:(UIKeyboardAppearance)keyboardAppearance {

--- a/app/terminal/term.js
+++ b/app/terminal/term.js
@@ -110,12 +110,38 @@ term.scrollPort_.onTouch = (e) => {
 };
 // Scroll to bottom wrapper
 exports.scrollToBottom = () => term.scrollEnd();
-// Set scroll position
-exports.newScrollTop = (y) => {
-    // two lines instead of one because the value you read out of scrollTop can be different from the value you write into it
+// Set scroll position and optionally forward delta as WheelEvents into hterm's
+// onMouse_ pipeline for mouse reporting (VT) and alternate screen arrow keys.
+let scrollDeltaRemainder = 0;
+exports.handleScroll = (y, delta) => {
     term.scrollPort_.screen_.scrollTop = y;
     lastScrollTop = term.scrollPort_.screen_.scrollTop;
+
+    if (delta === 0) return;
+    if (term.vt.mouseReport === term.vt.MOUSE_REPORT_DISABLED && term.isPrimaryScreen())
+        return;
+
+    const charH = term.scrollPort_.characterSize.height;
+    if (!charH) return;
+
+    scrollDeltaRemainder += delta;
+    const lines = Math.trunc(scrollDeltaRemainder / charH);
+    if (lines === 0) return;
+    scrollDeltaRemainder -= lines * charH;
+
+    const abs = Math.abs(lines);
+    const down = lines > 0;
+    for (let i = 0; i < abs; i++) {
+        term.scrollPort_.screen_.dispatchEvent(new WheelEvent('wheel', {
+            deltaY: down ? 1 : -1,
+            deltaMode: WheelEvent.DOM_DELTA_LINE,
+            bubbles: true,
+            cancelable: true,
+        }));
+    }
 };
+// Keep old name for compatibility
+exports.newScrollTop = (y) => exports.handleScroll(y, 0);
 
 // Send scroll height and position to native code
 let lastScrollHeight, lastScrollTop;
@@ -154,6 +180,7 @@ exports.getCharacterSize = () => {
 };
 
 exports.clearScrollback = () => term.clearScrollback();
+
 exports.setUserGesture = () => term.accessibilityReader_.hasUserGesture = true;
 
 hterm.openUrl = (url) => native.openLink(url);

--- a/app/terminal/term.js
+++ b/app/terminal/term.js
@@ -110,38 +110,12 @@ term.scrollPort_.onTouch = (e) => {
 };
 // Scroll to bottom wrapper
 exports.scrollToBottom = () => term.scrollEnd();
-// Set scroll position and optionally forward delta as WheelEvents into hterm's
-// onMouse_ pipeline for mouse reporting (VT) and alternate screen arrow keys.
-let scrollDeltaRemainder = 0;
-exports.handleScroll = (y, delta) => {
+// Set scroll position
+exports.newScrollTop = (y) => {
+    // two lines instead of one because the value you read out of scrollTop can be different from the value you write into it
     term.scrollPort_.screen_.scrollTop = y;
     lastScrollTop = term.scrollPort_.screen_.scrollTop;
-
-    if (delta === 0) return;
-    if (term.vt.mouseReport === term.vt.MOUSE_REPORT_DISABLED && term.isPrimaryScreen())
-        return;
-
-    const charH = term.scrollPort_.characterSize.height;
-    if (!charH) return;
-
-    scrollDeltaRemainder += delta;
-    const lines = Math.trunc(scrollDeltaRemainder / charH);
-    if (lines === 0) return;
-    scrollDeltaRemainder -= lines * charH;
-
-    const abs = Math.abs(lines);
-    const down = lines > 0;
-    for (let i = 0; i < abs; i++) {
-        term.scrollPort_.screen_.dispatchEvent(new WheelEvent('wheel', {
-            deltaY: down ? 1 : -1,
-            deltaMode: WheelEvent.DOM_DELTA_LINE,
-            bubbles: true,
-            cancelable: true,
-        }));
-    }
 };
-// Keep old name for compatibility
-exports.newScrollTop = (y) => exports.handleScroll(y, 0);
 
 // Send scroll height and position to native code
 let lastScrollHeight, lastScrollTop;
@@ -180,6 +154,29 @@ exports.getCharacterSize = () => {
 };
 
 exports.clearScrollback = () => term.clearScrollback();
+
+// Forward scroll delta as synthetic WheelEvents into hterm's onMouse_ pipeline.
+let scrollDeltaRemainder = 0;
+exports.handleScrollDelta = (delta) => {
+    if (term.vt.mouseReport === term.vt.MOUSE_REPORT_DISABLED && term.isPrimaryScreen())
+        return;
+    const charH = term.scrollPort_.characterSize.height;
+    if (!charH) return;
+    scrollDeltaRemainder += delta;
+    const lines = Math.trunc(scrollDeltaRemainder / charH);
+    if (lines === 0) return;
+    scrollDeltaRemainder -= lines * charH;
+    const abs = Math.abs(lines);
+    const down = lines > 0;
+    for (let i = 0; i < abs; i++) {
+        term.scrollPort_.screen_.dispatchEvent(new WheelEvent('wheel', {
+            deltaY: down ? 1 : -1,
+            deltaMode: WheelEvent.DOM_DELTA_LINE,
+            bubbles: true,
+            cancelable: true,
+        }));
+    }
+};
 
 exports.setUserGesture = () => term.accessibilityReader_.hasUserGesture = true;
 

--- a/app/terminal/term.js
+++ b/app/terminal/term.js
@@ -166,13 +166,10 @@ exports.handleScrollDelta = (delta) => {
     const lines = Math.trunc(scrollDeltaRemainder / charH);
     if (lines === 0) return;
     scrollDeltaRemainder -= lines * charH;
-    const abs = Math.abs(lines);
-    const down = lines > 0;
-    for (let i = 0; i < abs; i++) {
+    for (let i = 0; i < Math.abs(lines); i++) {
         term.scrollPort_.screen_.dispatchEvent(new WheelEvent('wheel', {
-            deltaY: down ? 1 : -1,
+            deltaY: lines > 0 ? 1 : -1,
             deltaMode: WheelEvent.DOM_DELTA_LINE,
-            bubbles: true,
             cancelable: true,
         }));
     }


### PR DESCRIPTION
Dispatches synthetic `WheelEvent`s into hterm's existing `onMouse_` pipeline so that touch scroll gestures reach programs that listen for them.

**When mouse reporting is active** (e.g. tmux `set -g mouse on`), hterm's `VT.onTerminalMouse_` generates the appropriate escape sequences. **When on the alternate screen** (less, vim, man), hterm's built-in alternate scroll mode (DECSET 1007) sends arrow keys. **On the primary screen with no mouse reporting**, the handler is a no-op and existing scrollback behavior is unchanged.

### Changes

`TerminalView.m`: compute scroll delta in `scrollViewDidScroll:` and forward to JS
`term.js`: add `handleScrollDelta` export that dispatches `WheelEvent`s to `scrollPort_.screen_`

### Test plan

- [ ] tmux with `set -g mouse on`: touch scroll enters copy-mode and scrolls
- [ ] `less` / `man`: touch scroll moves through content
- [ ] Primary screen shell prompt: scrollback works as before

Fixes #2375
Fixes #2537