### PR TITLE
fix: COW use-after-free race and missing sa_len on BSD sockaddr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: iSH.app
-          path: build/DerivedData/Build/Products/Release-iphoneos/iSH.app
+          path: build/DerivedData/Build/Products/*/iSH.app
       - name: Build
         if: matrix.kernel == 'linux'
         run: xcodebuild -project iSH.xcodeproj -scheme iSH+Linux -arch x86_64 -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,13 @@ jobs:
         run: deps/clone-linux.sh
       - name: Build
         if: matrix.kernel == 'ish'
-        run: xcodebuild -project iSH.xcodeproj -scheme iSH -arch arm64 -sdk iphoneos CODE_SIGNING_ALLOWED=NO
+        run: xcodebuild -project iSH.xcodeproj -scheme iSH -arch arm64 -sdk iphoneos CODE_SIGNING_ALLOWED=NO -derivedDataPath build/DerivedData
+      - name: Upload app
+        if: matrix.kernel == 'ish'
+        uses: actions/upload-artifact@v4
+        with:
+          name: iSH.app
+          path: build/DerivedData/Build/Products/Release-iphoneos/iSH.app
       - name: Build
         if: matrix.kernel == 'linux'
         run: xcodebuild -project iSH.xcodeproj -scheme iSH+Linux -arch x86_64 -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO

--- a/fs/sock.c
+++ b/fs/sock.c
@@ -236,6 +236,22 @@ static int sockaddr_read_bind(addr_t sockaddr_addr, void *sockaddr, uint_t *sock
     struct sockaddr_ *fake_addr = sockaddr;
     real_addr->sa_family = sock_family_to_real(fake_addr->family);
 
+    // BSD/macOS sockaddr has a sa_len field (first byte) that Linux does not.
+    // After translating the family, set sa_len to the correct structure size.
+#ifdef __APPLE__
+    switch (real_addr->sa_family) {
+        case PF_INET:
+            real_addr->sa_len = sizeof(struct sockaddr_in);
+            break;
+        case PF_INET6:
+            real_addr->sa_len = sizeof(struct sockaddr_in6);
+            break;
+        case PF_LOCAL:
+            real_addr->sa_len = *sockaddr_len;
+            break;
+    }
+#endif
+
     switch (real_addr->sa_family) {
         case PF_INET:
             if (*sockaddr_len < sizeof(struct sockaddr_in))

--- a/kernel/memory.c
+++ b/kernel/memory.c
@@ -276,13 +276,27 @@ void *mem_ptr(struct mem *mem, addr_t addr, int type) {
         asbestos_invalidate_page(mem->mmu.asbestos, page);
         // if page is cow, ~~milk~~ copy it
         if (entry->flags & P_COW) {
-            void *data = (char *) entry->data->data + entry->offset;
             void *copy = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
                     MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+            if (copy == MAP_FAILED)
+                return NULL;
 
             // copy/paste from above
             read_wrunlock(&mem->lock);
             write_wrlock(&mem->lock);
+
+            // Re-lookup after lock upgrade: another thread may have
+            // unmapped this page or resolved the COW in the window
+            // between releasing the read lock and acquiring the write lock.
+            entry = mem_pt(mem, page);
+            if (entry == NULL || !(entry->flags & P_COW)) {
+                munmap(copy, PAGE_SIZE);
+                write_wrunlock(&mem->lock);
+                read_wrlock(&mem->lock);
+                return mem_ptr(mem, addr, type);
+            }
+
+            void *data = (char *) entry->data->data + entry->offset;
             memcpy(copy, data, PAGE_SIZE);
             pt_map(mem, page, 1, copy, 0, entry->flags &~ P_COW);
             write_wrunlock(&mem->lock);


### PR DESCRIPTION
## Summary

Two bug fixes discovered while running Node.js (Claude Code) on iSH on iPad:

- **COW use-after-free in `mem_ptr()`**: In the COW path, `data` pointer and `entry` were captured while holding the read lock, then used after a lock upgrade (read→write) without re-validation. Another thread sharing the address space via `CLONE_VM` could `munmap` the backing memory during the lock upgrade window, causing `memcpy` to access freed host memory (SIGSEGV in `_platform_memmove`). Fix: re-lookup `pt_entry` after acquiring the write lock.

- **Missing `sa_len` on macOS/BSD sockaddr**: Linux `sockaddr` uses `uint16_t sa_family`, while BSD uses `uint8_t sa_len` + `uint8_t sa_family`. When translating from Linux format, `sa_len` was left containing garbage (the low byte of the Linux family field), causing `connect()` to return `EINVAL` on macOS/iOS. Fix: set `sa_len` to the correct structure size after family translation.

## Test plan

- [x] Build succeeds on macOS CI (`xcodebuild -scheme iSH -arch arm64 -sdk iphoneos`)
- [ ] Run multi-threaded Node.js workload in iSH (reproduces COW crash before fix)
- [ ] TCP connect to external hosts works (reproduces EINVAL before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)