### PR TITLE
Create standard devices for command line runs

### DIFF
--- a/app/AppDelegate.m
+++ b/app/AppDelegate.m
@@ -89,7 +89,7 @@ static NSString *const kSkipStartupMessage = @"Skip Startup Message";
 
     FsInitialize();
 
-    create_standard_devices();
+    create_some_device_nodes();
     
     // Permissions on / have been broken for a while, let's fix them
     generic_setattrat(AT_PWD, "/", (struct attr) {.type = attr_mode, .mode = 0755}, false);

--- a/app/AppDelegate.m
+++ b/app/AppDelegate.m
@@ -89,27 +89,7 @@ static NSString *const kSkipStartupMessage = @"Skip Startup Message";
 
     FsInitialize();
 
-    // create some device nodes
-    // this will do nothing if they already exist
-    generic_mknodat(AT_PWD, "/dev/tty1", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 1));
-    generic_mknodat(AT_PWD, "/dev/tty2", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 2));
-    generic_mknodat(AT_PWD, "/dev/tty3", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 3));
-    generic_mknodat(AT_PWD, "/dev/tty4", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 4));
-    generic_mknodat(AT_PWD, "/dev/tty5", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 5));
-    generic_mknodat(AT_PWD, "/dev/tty6", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 6));
-    generic_mknodat(AT_PWD, "/dev/tty7", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 7));
-
-    generic_mknodat(AT_PWD, "/dev/tty", S_IFCHR|0666, dev_make(TTY_ALTERNATE_MAJOR, DEV_TTY_MINOR));
-    generic_mknodat(AT_PWD, "/dev/console", S_IFCHR|0666, dev_make(TTY_ALTERNATE_MAJOR, DEV_CONSOLE_MINOR));
-    generic_mknodat(AT_PWD, "/dev/ptmx", S_IFCHR|0666, dev_make(TTY_ALTERNATE_MAJOR, DEV_PTMX_MINOR));
-
-    generic_mknodat(AT_PWD, "/dev/null", S_IFCHR|0666, dev_make(MEM_MAJOR, DEV_NULL_MINOR));
-    generic_mknodat(AT_PWD, "/dev/zero", S_IFCHR|0666, dev_make(MEM_MAJOR, DEV_ZERO_MINOR));
-    generic_mknodat(AT_PWD, "/dev/full", S_IFCHR|0666, dev_make(MEM_MAJOR, DEV_FULL_MINOR));
-    generic_mknodat(AT_PWD, "/dev/random", S_IFCHR|0666, dev_make(MEM_MAJOR, DEV_RANDOM_MINOR));
-    generic_mknodat(AT_PWD, "/dev/urandom", S_IFCHR|0666, dev_make(MEM_MAJOR, DEV_URANDOM_MINOR));
-    
-    generic_mkdirat(AT_PWD, "/dev/pts", 0755);
+    create_standard_devices();
     
     // Permissions on / have been broken for a while, let's fix them
     generic_setattrat(AT_PWD, "/", (struct attr) {.type = attr_mode, .mode = 0755}, false);

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -3,9 +3,11 @@
 #include <sys/stat.h>
 #include "fs/devices.h"
 #include "fs/fd.h"
+#include "fs/path.h"
 #include "fs/real.h"
 #include "fs/tty.h"
 #include "kernel/calls.h"
+#include "kernel/fs.h"
 #include "kernel/init.h"
 #include "kernel/personality.h"
 
@@ -123,6 +125,30 @@ extern int console_minor;
 void set_console_device(int major, int minor) {
     console_major = major;
     console_minor = minor;
+}
+
+static void create_device_node(const char *path, int major, int minor) {
+    generic_mknodat(AT_PWD, path, S_IFCHR|0666, dev_make(major, minor));
+}
+
+void create_standard_devices(void) {
+    for (int tty = 1; tty <= 7; tty++) {
+        char path[] = "/dev/tty0";
+        path[8] = '0' + tty;
+        create_device_node(path, TTY_CONSOLE_MAJOR, tty);
+    }
+
+    create_device_node("/dev/tty", TTY_ALTERNATE_MAJOR, DEV_TTY_MINOR);
+    create_device_node("/dev/console", TTY_ALTERNATE_MAJOR, DEV_CONSOLE_MINOR);
+    create_device_node("/dev/ptmx", TTY_ALTERNATE_MAJOR, DEV_PTMX_MINOR);
+
+    create_device_node("/dev/null", MEM_MAJOR, DEV_NULL_MINOR);
+    create_device_node("/dev/zero", MEM_MAJOR, DEV_ZERO_MINOR);
+    create_device_node("/dev/full", MEM_MAJOR, DEV_FULL_MINOR);
+    create_device_node("/dev/random", MEM_MAJOR, DEV_RANDOM_MINOR);
+    create_device_node("/dev/urandom", MEM_MAJOR, DEV_URANDOM_MINOR);
+
+    generic_mkdirat(AT_PWD, "/dev/pts", 0755);
 }
 
 int create_stdio(const char *file, int major, int minor) {

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -127,26 +127,26 @@ void set_console_device(int major, int minor) {
     console_minor = minor;
 }
 
-static void create_device_node(const char *path, int major, int minor) {
-    generic_mknodat(AT_PWD, path, S_IFCHR|0666, dev_make(major, minor));
-}
+void create_some_device_nodes(void) {
+    // create some device nodes
+    // this will do nothing if they already exist
+    generic_mknodat(AT_PWD, "/dev/tty1", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 1));
+    generic_mknodat(AT_PWD, "/dev/tty2", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 2));
+    generic_mknodat(AT_PWD, "/dev/tty3", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 3));
+    generic_mknodat(AT_PWD, "/dev/tty4", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 4));
+    generic_mknodat(AT_PWD, "/dev/tty5", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 5));
+    generic_mknodat(AT_PWD, "/dev/tty6", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 6));
+    generic_mknodat(AT_PWD, "/dev/tty7", S_IFCHR|0666, dev_make(TTY_CONSOLE_MAJOR, 7));
 
-void create_standard_devices(void) {
-    for (int tty = 1; tty <= 7; tty++) {
-        char path[] = "/dev/tty0";
-        path[8] = '0' + tty;
-        create_device_node(path, TTY_CONSOLE_MAJOR, tty);
-    }
+    generic_mknodat(AT_PWD, "/dev/tty", S_IFCHR|0666, dev_make(TTY_ALTERNATE_MAJOR, DEV_TTY_MINOR));
+    generic_mknodat(AT_PWD, "/dev/console", S_IFCHR|0666, dev_make(TTY_ALTERNATE_MAJOR, DEV_CONSOLE_MINOR));
+    generic_mknodat(AT_PWD, "/dev/ptmx", S_IFCHR|0666, dev_make(TTY_ALTERNATE_MAJOR, DEV_PTMX_MINOR));
 
-    create_device_node("/dev/tty", TTY_ALTERNATE_MAJOR, DEV_TTY_MINOR);
-    create_device_node("/dev/console", TTY_ALTERNATE_MAJOR, DEV_CONSOLE_MINOR);
-    create_device_node("/dev/ptmx", TTY_ALTERNATE_MAJOR, DEV_PTMX_MINOR);
-
-    create_device_node("/dev/null", MEM_MAJOR, DEV_NULL_MINOR);
-    create_device_node("/dev/zero", MEM_MAJOR, DEV_ZERO_MINOR);
-    create_device_node("/dev/full", MEM_MAJOR, DEV_FULL_MINOR);
-    create_device_node("/dev/random", MEM_MAJOR, DEV_RANDOM_MINOR);
-    create_device_node("/dev/urandom", MEM_MAJOR, DEV_URANDOM_MINOR);
+    generic_mknodat(AT_PWD, "/dev/null", S_IFCHR|0666, dev_make(MEM_MAJOR, DEV_NULL_MINOR));
+    generic_mknodat(AT_PWD, "/dev/zero", S_IFCHR|0666, dev_make(MEM_MAJOR, DEV_ZERO_MINOR));
+    generic_mknodat(AT_PWD, "/dev/full", S_IFCHR|0666, dev_make(MEM_MAJOR, DEV_FULL_MINOR));
+    generic_mknodat(AT_PWD, "/dev/random", S_IFCHR|0666, dev_make(MEM_MAJOR, DEV_RANDOM_MINOR));
+    generic_mknodat(AT_PWD, "/dev/urandom", S_IFCHR|0666, dev_make(MEM_MAJOR, DEV_URANDOM_MINOR));
 
     generic_mkdirat(AT_PWD, "/dev/pts", 0755);
 }

--- a/kernel/init.h
+++ b/kernel/init.h
@@ -8,6 +8,7 @@ int mount_root(const struct fs_ops *fs, const char *source);
 void set_console_device(int major, int minor);
 int become_first_process(void);
 int become_new_init_child(void);
+void create_standard_devices(void);
 int create_stdio(const char *file, int major, int minor);
 int create_piped_stdio(void);
 

--- a/kernel/init.h
+++ b/kernel/init.h
@@ -8,7 +8,7 @@ int mount_root(const struct fs_ops *fs, const char *source);
 void set_console_device(int major, int minor);
 int become_first_process(void);
 int become_new_init_child(void);
-void create_standard_devices(void);
+void create_some_device_nodes(void);
 int create_stdio(const char *file, int major, int minor);
 int create_piped_stdio(void);
 

--- a/main.c
+++ b/main.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "kernel/calls.h"
+#include "kernel/init.h"
 #include "kernel/task.h"
 #include "xX_main_Xx.h"
 
@@ -13,6 +14,7 @@ int main(int argc, char *const argv[]) {
         fprintf(stderr, "xX_main_Xx: %s\n", strerror(-err));
         return err;
     }
+    create_standard_devices();
     do_mount(&procfs, "proc", "/proc", "", 0);
     do_mount(&devptsfs, "devpts", "/dev/pts", "", 0);
     task_run_current();

--- a/main.c
+++ b/main.c
@@ -14,7 +14,7 @@ int main(int argc, char *const argv[]) {
         fprintf(stderr, "xX_main_Xx: %s\n", strerror(-err));
         return err;
     }
-    create_standard_devices();
+    create_some_device_nodes();
     do_mount(&procfs, "proc", "/proc", "", 0);
     do_mount(&devptsfs, "devpts", "/dev/pts", "", 0);
     task_run_current();


### PR DESCRIPTION
## Summary

Create standard `/dev` nodes during command-line emulator startup.

The iOS app startup already creates `/dev/ptmx`, but the CLI path only mounted
`devpts` at `/dev/pts`. Static i386 `tmux` could start and parse commands, but
failed when creating the first pane because `forkpty` could not open the pty
master:

```text
create window failed: fork failed: No such file or directory
```

This moves the existing standard device-node setup into shared kernel init code
and calls it from both app and CLI startup. The CLI path now gets `/dev/ptmx`
before mounting `devpts`, without duplicating the app's `/dev` setup list.

## Validation

- `ninja -C build`
- Removed `/dev/ptmx` from the Alpine test filesystem, then confirmed the
  rebuilt CLI emulator recreated it on startup.
- Ran static i386 `tmux` in Alpine:
  - `tmux -V`
  - `tmux -h`
  - `tmux -L final-smoke -f /dev/null new-session -d /bin/true`
