### PR TITLE
Fix terminal startup blur state

### DIFF
--- a/app/TerminalView.m
+++ b/app/TerminalView.m
@@ -134,6 +134,7 @@ static NSString *const HANDLERS[] = {@"syncFocus", @"focus", @"newScrollHeight",
 
     self.scrollbarView.contentView = webView;
     [self.scrollbarView addSubview:webView];
+    [self syncTerminalFocus];
 }
 
 - (void)uninstallTerminalView {
@@ -202,7 +203,13 @@ static NSString *const HANDLERS[] = {@"syncFocus", @"focus", @"newScrollHeight",
 
 - (void)setTerminalFocused:(BOOL)terminalFocused {
     _terminalFocused = terminalFocused;
-    NSString *script = terminalFocused ? @"exports.setFocused(true)" : @"exports.setFocused(false)";
+    [self syncTerminalFocus];
+}
+
+- (void)syncTerminalFocus {
+    if (!self.terminal.loaded)
+        return;
+    NSString *script = _terminalFocused ? @"exports.setFocused(true)" : @"exports.setFocused(false)";
     [self.terminal.webView evaluateJavaScript:script completionHandler:nil];
 }
 

--- a/app/terminal/term.js
+++ b/app/terminal/term.js
@@ -85,7 +85,7 @@ exports.copy = () => term.copySelectionToClipboard();
 // This listener blocks blur events that come in because the webview has lost first responder
 term.scrollPort_.screen_.addEventListener('blur', (e) => {
     if (e.target.ownerDocument.activeElement == e.target) {
-        e.stopPropagation();
+        e.stopImmediatePropagation();
     }
 }, {capture: true});
 term.scrollPort_.screen_.addEventListener('mousedown', (e) => {


### PR DESCRIPTION
## Summary

Fix an intermittent startup race that could leave the terminal in hterm's unfocused/blurred visual state.

The native focus state is now replayed after the WebView is installed, and internal WebView blur events are fully suppressed before hterm handles them.
