### PR TITLE
Fix sigaltstack error path leaking sighand lock

### DIFF
--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -607,8 +607,10 @@ dword_t sys_sigaltstack(addr_t ss_addr, addr_t old_ss_addr) {
         if (ss.flags & SS_DISABLE_) {
             sighand->altstack = 0;
         } else {
-            if (ss.size < MINSIGSTKSZ_)
+            if (ss.size < MINSIGSTKSZ_) {
+                unlock(&sighand->lock);
                 return _ENOMEM;
+            }
             sighand->altstack = ss.stack;
             sighand->altstack_size = ss.size;
         }


### PR DESCRIPTION
`sys_sigaltstack()` returns `_ENOMEM` while still holding `sighand->lock` when the new alt stack is smaller than `MINSIGSTKSZ_`, causing a permanent lock leak/deadlock on later signal operations.

#### A simple reproducer:
```c
#define _GNU_SOURCE
#include <errno.h>
#include <signal.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/syscall.h>
#include <unistd.h>
int main(void) {
    setvbuf(stdout, NULL, _IONBF, 0);
    stack_t ss = {0};
    ss.ss_sp = malloc(1);
    ss.ss_size = 1; // intentionally smaller than MINSIGSTKSZ
    ss.ss_flags = 0;
    printf("[1] calling sigaltstack(tiny stack)...\n");
    errno = 0;
    long r = syscall(SYS_sigaltstack, &ss, NULL);
    printf("[1] ret=%ld errno=%d (%s)\n", r, errno, strerror(errno));
    return 0;
}
```

When this reproducer is compiled and run inside the iSH app, the whole app becomes stuck after the first failing `sigaltstack()` call.