### PR TITLE
sched_getaffinity: report 1 CPU instead of host count

### DIFF
--- a/kernel/resource.c
+++ b/kernel/resource.c
@@ -202,7 +202,10 @@ int_t sys_sched_getaffinity(pid_t_ pid, dword_t cpusetsize, addr_t cpuset_addr) 
             return _ESRCH;
     }
 
-    unsigned cpus = sysconf(_SC_NPROCESSORS_ONLN);
+    // Report 1 CPU. iSH is a single-core emulator; returning the host CPU
+    // count misleads runtimes like Go into spawning N OS threads that all
+    // serialize inside iSH's emulation loop, wasting CPU and causing heat.
+    unsigned cpus = 1;
     char cpuset[cpus / 8 + 1];
     if (cpusetsize < sizeof(cpuset))
         return _EINVAL;


### PR DESCRIPTION
## Problem

`sched_getaffinity` currently returns the host iPhone's CPU count via `sysconf(_SC_NPROCESSORS_ONLN)` (typically 6–8 on modern iPhones). This misleads multi-threaded runtimes into spawning N OS threads.

The most visible impact is with **Go programs**: Go reads `sched_getaffinity` at startup to set `GOMAXPROCS`. With a reported count of 8, Go's scheduler spawns 8 OS threads, each backed by an iSH pthread running its own emulation loop. Since iSH serializes all emulated execution, these threads contend constantly — producing excessive CPU usage and device heat without any throughput benefit.

Tested with [Conduit](https://github.com/Psiphon-Inc/conduit), a Go-based proxy: reducing `GOMAXPROCS` to 1 (via `runtime.GOMAXPROCS(1)` in the binary as a workaround) dramatically reduced heat and CPU load on iPhone.

## Fix

Report `1` CPU, which accurately reflects iSH's single-core emulation model.

```c
// Before
unsigned cpus = sysconf(_SC_NPROCESSORS_ONLN);

// After
unsigned cpus = 1; // iSH is single-core; host count misleads thread schedulers
```

## Impact

- Go programs default to `GOMAXPROCS=1` — correct for iSH
- Other runtimes (Node.js, Python multiprocessing, etc.) also benefit
- No behaviour change for single-threaded programs