### PR TITLE
signal: remove SIGURG from default-ignore list

### DIFF
--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -38,7 +38,7 @@ static int signal_action(struct sighand *sighand, int sig) {
     }
 
     switch (sig) {
-        case SIGURG_: case SIGCONT_: case SIGCHLD_:
+        case SIGCONT_: case SIGCHLD_:
         case SIGIO_: case SIGWINCH_:
             return SIGNAL_IGNORE;
 


### PR DESCRIPTION
## Problem

`SIGURG` is currently in iSH's default-ignore list in `kernel/signal.c`:

```c
case SIGURG_: case SIGCONT_: case SIGCHLD_:
case SIGIO_: case SIGWINCH_:
    return SIGNAL_IGNORE;
```

**Go 1.14+** uses `SIGURG` to implement asynchronous goroutine preemption (`runtime/signal_unix.go`). When a Go program calls `signal.Notify` or the runtime installs its own `SIGURG` handler via `runtime_sigInstall`, iSH's default-ignore classification prevents proper handler registration.

The result is a hard crash on startup:
```
fatal: bad g in signal handler
```

The workaround is to set `GODEBUG=asyncpreemptoff=1` before launch, which disables Go's async preemption entirely — a significant runtime regression.

## Fix

Remove `SIGURG_` from the ignore list. Its POSIX default disposition is already "ignored" for processes that haven't installed a handler, so removing it from this list has no effect on programs that don't use `SIGURG`. It only allows programs like Go to successfully install their own handler.

```c
// Before
case SIGURG_: case SIGCONT_: case SIGCHLD_:

// After
case SIGCONT_: case SIGCHLD_:
```

## Impact

- Go 1.14+ programs start without `GODEBUG=asyncpreemptoff=1`
- No behavioural change for programs that don't use `SIGURG`
- Tested with [Conduit](https://github.com/Psiphon-Inc/conduit) on iSH (Alpine Linux, iPhone)