### PR TITLE
Fix accept4 (socketcall 18) unimplemented issue causing Go applications to fail

### DIFF
--- a/fs/fd.c
+++ b/fs/fd.c
@@ -226,21 +226,6 @@ void fdtable_do_cloexec(struct fdtable *table) {
     unlock(&table->lock);
 }
 
-#define F_DUPFD_ 0
-#define F_GETFD_ 1
-#define F_SETFD_ 2
-#define F_GETFL_ 3
-#define F_SETFL_ 4
-
-#define F_GETLK_ 5
-#define F_SETLK_ 6
-#define F_SETLKW_ 7
-#define F_GETLK64_ 12
-#define F_SETLK64_ 13
-#define F_SETLKW64_ 14
-
-#define F_DUPFD_CLOEXEC_ 1030
-
 dword_t sys_dup(fd_t f) {
     STRACE("dup(%d)", f);
     struct fd *fd = f_get(f);

--- a/fs/fd.h
+++ b/fs/fd.h
@@ -124,6 +124,21 @@ struct dir_entry {
     char name[NAME_MAX + 1];
 };
 
+#define F_DUPFD_ 0
+#define F_GETFD_ 1
+#define F_SETFD_ 2
+#define F_GETFL_ 3
+#define F_SETFL_ 4
+
+#define F_GETLK_ 5
+#define F_SETLK_ 6
+#define F_SETLKW_ 7
+#define F_GETLK64_ 12
+#define F_SETLK64_ 13
+#define F_SETLKW64_ 14
+
+#define F_DUPFD_CLOEXEC_ 1030
+
 #define LSEEK_SET 0
 #define LSEEK_CUR 1
 #define LSEEK_END 2

--- a/fs/sock.c
+++ b/fs/sock.c
@@ -456,13 +456,14 @@ int_t sys_accept4(fd_t sock_fd, addr_t sockaddr_addr, addr_t sockaddr_len_addr, 
     fd_t client = sys_accept(sock_fd, sockaddr_addr, sockaddr_len_addr);
     if (client < 0)
         return client;
-    if (flags & SOCK_NONBLOCK_)
-        sys_fcntl(client, F_SETFL_, O_NONBLOCK_);
+    if (flags & SOCK_NONBLOCK_) {
+        int_t old = sys_fcntl(client, F_GETFL_, 0);
+        sys_fcntl(client, F_SETFL_, old | O_NONBLOCK_);
+    }
     if (flags & SOCK_CLOEXEC_)
         sys_fcntl(client, F_SETFD_, 1);
     return client;
 }
-
 
 static void copy_unix_name(char *sockaddr, dword_t *sockaddr_len, struct fd *sock) {
     struct sockaddr_ *fake_addr = (void *) sockaddr;

--- a/fs/sock.c
+++ b/fs/sock.c
@@ -450,6 +450,19 @@ int_t sys_accept(fd_t sock_fd, addr_t sockaddr_addr, addr_t sockaddr_len_addr) {
     return client_f;
 }
 
+int_t sys_accept4(fd_t sock_fd, addr_t sockaddr_addr,
+                  addr_t sockaddr_len_addr, int_t flags) {
+    fd_t client = sys_accept(sock_fd, sockaddr_addr, sockaddr_len_addr);
+    if (client < 0)
+        return client;
+    if (flags & SOCK_NONBLOCK_)
+        sys_fcntl(client, F_SETFL_, O_NONBLOCK_);
+    if (flags & SOCK_CLOEXEC_)
+        sys_fcntl(client, F_SETFD_, 1);
+    return client;
+}
+
+
 static void copy_unix_name(char *sockaddr, dword_t *sockaddr_len, struct fd *sock) {
     struct sockaddr_ *fake_addr = (void *) sockaddr;
     fake_addr->family = PF_LOCAL_;
@@ -1214,7 +1227,7 @@ static struct socket_call {
     {(syscall_t) sys_getsockopt, 5},
     {(syscall_t) sys_sendmsg, 3},
     {(syscall_t) sys_recvmsg, 3},
-    {NULL}, // accept4
+    {(syscall_t) sys_accept4, 4},
     {NULL}, // recvmmsg
     {(syscall_t) sys_sendmmsg, 4},
 };

--- a/fs/sock.c
+++ b/fs/sock.c
@@ -450,8 +450,9 @@ int_t sys_accept(fd_t sock_fd, addr_t sockaddr_addr, addr_t sockaddr_len_addr) {
     return client_f;
 }
 
-int_t sys_accept4(fd_t sock_fd, addr_t sockaddr_addr,
-                  addr_t sockaddr_len_addr, int_t flags) {
+int_t sys_accept4(fd_t sock_fd, addr_t sockaddr_addr, addr_t sockaddr_len_addr, int_t flags) {
+    if (flags & ~(SOCK_NONBLOCK_ | SOCK_CLOEXEC_))
+        return _EINVAL;
     fd_t client = sys_accept(sock_fd, sockaddr_addr, sockaddr_len_addr);
     if (client < 0)
         return client;

--- a/fs/sock.h
+++ b/fs/sock.h
@@ -16,6 +16,7 @@ int_t sys_bind(fd_t sock_fd, addr_t sockaddr_addr, uint_t sockaddr_len);
 int_t sys_connect(fd_t sock_fd, addr_t sockaddr_addr, uint_t sockaddr_len);
 int_t sys_listen(fd_t sock_fd, int_t backlog);
 int_t sys_accept(fd_t sock_fd, addr_t sockaddr_addr, addr_t sockaddr_len_addr);
+int_t sys_accept4(fd_t sock_fd, addr_t sockaddr_addr, addr_t sockaddr_len_addr, int_t flags);
 int_t sys_getsockname(fd_t sock_fd, addr_t sockaddr_addr, addr_t sockaddr_len_addr);
 int_t sys_getpeername(fd_t sock_fd, addr_t sockaddr_addr, addr_t sockaddr_len_addr);
 int_t sys_socketpair(dword_t domain, dword_t type, dword_t protocol, addr_t sockets_addr);

--- a/tests/e2e/accept4/expected.txt
+++ b/tests/e2e/accept4/expected.txt
@@ -1,0 +1,1 @@
+accept4 ok

--- a/tests/e2e/accept4/test.sh
+++ b/tests/e2e/accept4/test.sh
@@ -1,0 +1,21 @@
+python3 -c "
+import socket, ctypes, ctypes.util, threading, time
+
+libc = ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', 19999))
+s.listen(1)
+
+def connect():
+    time.sleep(0.3)
+    c = socket.socket()
+    c.connect(('127.0.0.1', 19999))
+
+threading.Thread(target=connect).start()
+
+args = (ctypes.c_ulong * 4)(s.fileno(), 0, 0, 0)
+result = libc.syscall(102, 18, args)
+err = ctypes.get_errno()
+print('accept4 ok' if result > 0 else 'accept4 failed errno=' + str(err))
+"


### PR DESCRIPTION
Fixes #1819

## Problem

On Linux x86_32, socket operations are multiplexed through socketcall (syscall 102). While most socketcall operations were implemented in iSH, accept4 (operation 18) was left unimplemented and returned ENOSYS.

The Go runtime prefers accept4 over accept on Linux. As a result, Go-based server applications such as Kubo (go-ipfs) could not start because accept4 failed immediately.

## Changes

- Move F_* fcntl constants from fs/fd.c to fs/fd.h so they can be shared with fs/sock.c
- Implement sys_accept4 using sys_accept followed by fcntl configuration
- Preserve existing file status flags via F_GETFL_ when applying O_NONBLOCK_
- Validate flags and return EINVAL for unsupported values
- Replace socketcall dispatch table entry 18 from NULL to sys_accept4
- Add an e2e test covering accept4 behavior

## Verification

Verified by directly invoking socketcall(102, 18, ...) from Python using ctypes.

Before:
- accept4 returned ENOSYS (errno 38)

After:
- accept4 successfully returns a connected client file descriptor

CI status:
- build-linux: passing
- build-mac: passing