### PR TITLE
asbestos: don't drop a poke that arrives while the fiber is running

### DIFF
--- a/asbestos/asbestos.c
+++ b/asbestos/asbestos.c
@@ -175,6 +175,17 @@ static inline size_t fiber_cache_hash(addr_t ip) {
     return (ip ^ (ip >> 12)) % FIBER_CACHE_SIZE;
 }
 
+// Copy the fiber frame's working cpu_state back out to the task's cpu_state,
+// preserving the live poke flag. cpu->poked_ptr points at cpu->_poked, but the
+// frame holds a whole-struct snapshot taken when the fiber was entered, so a
+// plain `*cpu = frame->cpu` writes that snapshot's stale _poked over the real
+// flag -- discarding a poke that arrived while the fiber was running.
+static inline void frame_sync_out(struct cpu_state *cpu, struct fiber_frame *frame) {
+    bool poked = __atomic_load_n(cpu->poked_ptr, __ATOMIC_SEQ_CST);
+    *cpu = frame->cpu;
+    __atomic_store_n(cpu->poked_ptr, poked, __ATOMIC_SEQ_CST);
+}
+
 static int cpu_step_to_interrupt(struct cpu_state *cpu, struct tlb *tlb) {
     struct asbestos *asbestos = cpu->mmu->asbestos;
     read_wrlock(&asbestos->jetsam_lock);
@@ -233,7 +244,7 @@ static int cpu_step_to_interrupt(struct cpu_state *cpu, struct tlb *tlb) {
             interrupt = INT_TIMER;
         if (interrupt == INT_NONE && ++frame->cpu.cycle % (1 << 10) == 0)
             interrupt = INT_TIMER;
-        *cpu = frame->cpu;
+        frame_sync_out(cpu, frame);
     }
 
     free(frame);


### PR DESCRIPTION
`cpu->poked_ptr` points at `cpu->_poked`, but the fiber frame holds a whole-struct snapshot of `cpu_state` taken when the fiber was entered. The `*cpu = frame->cpu` at the end of each dispatch iteration therefore writes that snapshot's stale `_poked` over the live flag, discarding any poke that landed while the fiber was running, including one arriving in the window between the `__atomic_exchange_n` just above it and the copy itself.

The consequence today is bounded: the task still leaves the fiber at the next cycle-counter tick, at most 1024 blocks later, so this costs latency rather than correctness. I am not reporting a hang.

It matters considerably more if that copy is ever hoisted out of the per-block path, which is a natural optimization to reach for. The chain gadgets exit to C on a pending poke *without* clearing the flag (`gadgets-aarch64/entry.S:24`, `gadgets-x86_64/entry.S:27`), and only the `INT_NONE` path clears it, so a stale `true` in the snapshot re-arms it permanently: the fiber then bails at the first poke check on every re-entry and makes no guest progress at all. I hit exactly that downstream in iSH-AOK while hoisting this copy. It presents as a task spinning at 100% CPU with its pc and cycle counter frozen, and it reproduces on the second forked command of a shell line.

`frame_sync_out()` loads the live flag, does the copy, and restores it.

### Testing

Built and exercised on an i686 Alpine rootfs (built with `tools/fakefsify`): fork/exec sequences, pipelines, in-guest `gcc -O2` compiles and busybox `awk` all behave identically to master. The equivalent change is running downstream in iSH-AOK across its i386, amd64, arm64 and riscv64 frontends, validated by its guest regression suite on each (~90 tests per architecture) and on device.

`meson test` fails identically with and without this patch on my machine (`float80` exits immediately, `e2e` fails while downloading Alpine), so it was not a useful signal either way.

### Not included

I also measured hoisting the copy out of the per-block path. It is worth 1.17x on a synthetic computed-goto dispatch benchmark upstream, but only ~2% on busybox `awk` and nothing measurable on an in-guest `gcc` compile, because upstream links backward edges and guest loops therefore stay inside `fiber_enter`. That did not seem like a good trade against added risk in the hottest loop, so this PR is the correctness fix only.
