### PR TITLE
Fix crash reading /proc/<pid>/mem

### DIFF
--- a/fs/proc.c
+++ b/fs/proc.c
@@ -96,12 +96,18 @@ static int proc_refresh_data(struct fd *fd) {
         return _EISDIR;
     assert(S_ISREG(mode));
 
+    struct proc_entry *entry = &fd->proc.entry;
+    // Entries backed by pread/pwrite (/proc/<pid>/mem) have no show function
+    // and nothing to buffer, so there is nothing to refresh. proc_seek gets
+    // here for them, and calling through the NULL show pointer crashes.
+    if (entry->meta->show == NULL)
+        return 0;
+
     if (fd->proc.data.data == NULL) {
         fd->proc.data.capacity = 4096;
         fd->proc.data.data = malloc(fd->proc.data.capacity); // default size
     }
     fd->proc.data.size = 0;
-    struct proc_entry *entry = &fd->proc.entry;
     int err = entry->meta->show(entry, &fd->proc.data);
     if (err < 0)
         return err;


### PR DESCRIPTION
`/proc/<pid>/mem` is the one proc entry served by `pread`/`pwrite` instead of `show`, so its `meta->show` is NULL.

`read()` on it has no `->read` op, falls back to `->pread`, and then advances the offset through `->lseek`, which is `proc_seek` -> `proc_refresh_data` -> `entry->meta->show(...)` — a call through a NULL pointer.

On master a plain `read()` of `/proc/self/mem` takes ish down with SIGSEGV. Any debugger or memory-map reader in the guest hits the same path.

`pread`/`pwrite` entries have no buffered show model, so there is nothing for `proc_refresh_data` to do; this returns early instead.

### Testing

Repro program run under `ish -f alpine`, and the same binary run on real Linux (x86 Ubuntu) to confirm the expected behavior:

```c
int fd = open("/proc/self/mem", O_RDONLY);
ssize_t n = read(fd, buf, sizeof(buf));      /* EIO on Linux, that's fine */
off_t off = lseek(fd, 0, SEEK_SET);
```

| | result |
|---|---|
| Linux | `read -> -1 (I/O error)`, `lseek -> 0`, survives |
| master | `SIGSEGV` |
| this branch | `read -> -1 (Operation not permitted)`, `lseek -> 0`, survives |

(The read errno differs from Linux's `EIO` — that's the pre-existing `proc_pid_mem_pread` behavior, untouched here.)

Also ran a shell smoke test over the Alpine rootfs (directory walks, `/proc` reads, fork/exec churn, redirects, pipes) with no change in behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)