### PR TITLE
Fix crashes reading /proc/<pid> of a task that is exiting

### DIFF
--- a/fs/fd.c
+++ b/fs/fd.c
@@ -143,7 +143,10 @@ static int fdtable_expand(struct fdtable *table, fd_t max) {
 }
 
 struct fd *fdtable_get(struct fdtable *table, fd_t f) {
-    if (f < 0 || (unsigned) f >= current->files->size)
+    // Bounds-check the table being indexed, not the calling task's. They are
+    // not always the same one: /proc/<pid>/fd reads another task's table, and
+    // fdtable_release walks a table the caller has already let go of.
+    if (f < 0 || (unsigned) f >= table->size)
         return NULL;
     return table->files[f];
 }

--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -269,7 +269,15 @@ static struct proc_dir_entry proc_pid_fd;
 static bool proc_pid_fd_readdir(struct proc_entry *entry, unsigned long *index, struct proc_entry *next_entry) {
     struct task *task = proc_get_task(entry);
     if (task == NULL)
-        return _ESRCH;
+        // This returns "is there another entry", not an error code. _ESRCH is
+        // nonzero, so it reads as true and proc_readdir goes on to use a
+        // next_entry that was never filled in.
+        return false;
+    if (task->files == NULL) {
+        // Exited, not yet reaped: do_exit dropped the fd table already.
+        proc_put_task(task);
+        return false;
+    }
     lock(&task->files->lock);
     while (*index < task->files->size && task->files->files[*index] == NULL)
         (*index)++;
@@ -289,9 +297,15 @@ static int proc_pid_fd_readlink(struct proc_entry *entry, char *buf) {
     struct task *task = proc_get_task(entry);
     if (task == NULL)
         return _ESRCH;
+    if (task->files == NULL) {
+        proc_put_task(task);
+        return _ESRCH;
+    }
     lock(&task->files->lock);
     struct fd *fd = fdtable_get(task->files, entry->fd);
-    int err = generic_getpath(fd, buf);
+    int err = _ENOENT;
+    if (fd != NULL)
+        err = generic_getpath(fd, buf);
     unlock(&task->files->lock);
     proc_put_task(task);
     return err;
@@ -302,7 +316,9 @@ static int proc_pid_exe_readlink(struct proc_entry *entry, char *buf) {
     if (task == NULL)
         return _ESRCH;
     lock(&task->general_lock);
-    int err = generic_getpath(task->mm->exefile, buf);
+    int err = _ESRCH;
+    if (task->mm != NULL)
+        err = generic_getpath(task->mm->exefile, buf);
     unlock(&task->general_lock);
     proc_put_task(task);
     return err;
@@ -329,6 +345,10 @@ static int proc_pid_cwd_readlink(struct proc_entry *entry, char *buf) {
     struct task *task = proc_get_task(entry);
     if (task == NULL)
         return _ESRCH;
+    if (task->fs == NULL) {
+        proc_put_task(task);
+        return _ESRCH;
+    }
     lock(&task->fs->lock);
     int err = generic_getpath(task->fs->pwd, buf);
     unlock(&task->fs->lock);

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -50,12 +50,21 @@ noreturn void do_exit(int status) {
     }
 
     // release all our resources
-    mm_release(current->mm);
+    // These are read by other threads through /proc/<pid>, which holds
+    // pids_lock for the whole access, so detach them under pids_lock -- a
+    // reader then sees either a pointer that is still ours to hand out, or
+    // NULL. The actual releasing has to happen outside the lock.
+    lock(&pids_lock);
+    struct mm *mm = current->mm;
+    struct fdtable *files = current->files;
+    struct fs_info *fs = current->fs;
     current->mm = NULL;
-    fdtable_release(current->files);
     current->files = NULL;
-    fs_info_release(current->fs);
     current->fs = NULL;
+    unlock(&pids_lock);
+    mm_release(mm);
+    fdtable_release(files);
+    fs_info_release(fs);
     // sighand must be released below so it can be protected by pids_lock
     // since it can be accessed by other threads
 


### PR DESCRIPTION
Repeatedly `opendir()`ing `/proc/<pid>/fd` of a child that exits during the walk kills ish with SIGSEGV. **20 runs out of 20 on master, 0 out of 20 with this change.** Three separate things go wrong on that path.

### 1. `_ESRCH` returned from a `bool` function

`proc_pid_fd_readdir` returns "did I produce another entry", but the task-lookup failure path returned `_ESRCH`. That is nonzero, so it reads as `true`, and `proc_readdir` goes on to use a `*next_entry` this path never wrote.

### 2. `do_exit` releases mm/files/fs outside `pids_lock`

A `/proc/<pid>` reader holds `pids_lock` across its whole access, but `do_exit` frees and clears `mm`, `files` and `fs` before taking it. The reader can load `task->files`, have `do_exit` free and clear it, then dereference it.

`kernel/exit.c` already handles exactly this for `sighand` — *"must be released below so it can be protected by pids_lock since it can be accessed by other threads"* — so this does the same for the other three. `proc_pid_fd_readdir` and the fd/exe/cwd readlinks now also check for NULL, as the `auxv` and `cmdline` handlers already did.

**Relationship to #2300.** @ShoichiroKitano reported this same problem 959 days ago (found via tmux, same root cause) and fixed it by moving `lock(&pids_lock)` up so it is held across the three release calls. That drew the objection that it breaks lock ordering, which looks fair to me: `mm_release`, `fdtable_release` and `fs_info_release` take fs, mount and mem locks in turn, so holding `pids_lock` across them inverts the order against paths that take those first.

This version avoids that: `pids_lock` is held only long enough to detach the three pointers, no second lock is taken inside that window, and the releasing happens after unlocking. A reader under `pids_lock` therefore sees either a pointer that is still valid or NULL, and the lock ordering is unchanged. Credit to @ShoichiroKitano for the original diagnosis — if you would rather take their PR with this adjustment, that works just as well.

### 3. `fdtable_get` bounds-checks the wrong table

```c
if (f < 0 || (unsigned) f >= current->files->size)
    return NULL;
return table->files[f];
```

It validates against the *calling* task's table while indexing the one it was passed. Those differ whenever the table is not the caller's own — reading another task's `/proc/<pid>/fd`, or `fdtable_release` walking a table after `do_exit` cleared `current->files`. So it either indexed out of bounds or, once the pointer was cleared, faulted on NULL. Fixing 2 without this one just moves the crash here.

### Testing

Repro: 400 rounds of forking a child that exits after 300us while the parent walks `/proc/<pid>/fd`.

| | result |
|---|---|
| Linux (x86 Ubuntu) | completes clean |
| master | SIGSEGV, 20/20 runs |
| this branch | completes clean, 20/20 runs |

Also ran a shell smoke test over an Alpine rootfs (directory walks, `/proc` reads of live and exiting children, fork/exec churn, redirects, pipes) 20x, plus a 200-way concurrent `ls -la` + `/proc/self/maps` + `readlink /proc/self/exe` workload. No regressions. That shell smoke also reproduces the crash on master, but only under machine load, so the dedicated repro above is the reliable signal.

`meson test` fails identically with and without this patch here (`float80` and `e2e` both fail on unmodified master on Apple Silicon), so it was not a useful signal either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)