### PR TITLE
Don't inherit POSIX timers across fork

### DIFF
--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -45,6 +45,10 @@ static struct tgroup *tgroup_copy(struct tgroup *old_group) {
         unlock(&group->tty->lock);
     }
     group->itimer = NULL;
+    // POSIX timers are not inherited across fork
+    for (int i = 0; i < TIMERS_MAX; i++) {
+        group->posix_timers[i] = (struct posix_timer) {};
+    }
     group->doing_group_exit = false;
     group->children_rusage = (struct rusage_) {};
     cond_init(&group->child_exit);


### PR DESCRIPTION
`tgroup_copy` does `*group = *old_group`, which copies `posix_timers[]` wholesale — including each entry's `struct timer *`. The child therefore starts life believing it owns the parent's timers, and `timer_delete` on an inherited id frees a timer object the parent still owns and whose callback is still armed.

Linux does not inherit POSIX timers across `fork`. (A thread clone shares the tgroup, so that case is already correct.) This clears the array in the copy.

### Testing

Repro: parent creates a `SIGEV_SIGNAL` timer, arms it, forks; the child calls `timer_delete` on the inherited id, and the parent then deletes its own.

| | child's `timer_delete(inherited)` | outcome |
|---|---|---|
| Linux (x86 Ubuntu) | `-1 EINVAL` | parent's timer unaffected |
| master | `0` (succeeds) | frees the parent's live timer, ish dies |
| this branch | `-1 EINVAL` | parent's own `timer_delete` still succeeds |

One thing to note while you are looking at this: POSIX timers do not appear to deliver signals at all on master, fork or no fork — a `SIGEV_SIGNAL` timer armed with a 20ms interval never fired in my testing, with no fork involved. That is a separate gap and this PR does not touch it, but it means the "parent's timer keeps firing" half of the story cannot currently be demonstrated. The double-free is independently reproducible as above.

Also ran a shell smoke test over an Alpine rootfs (directory walks, `/proc` reads, fork/exec churn, redirects, pipes) with no change in behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)