### PR TITLE
Return EINVAL from getdents when the buffer is too small

### DIFF
--- a/fs/dir.c
+++ b/fs/dir.c
@@ -92,8 +92,15 @@ int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
             printed++;
         }
 
-        if (reclen > count)
+        if (reclen > count) {
+            if (count == orig_count) {
+                // If the buffer isn't large enough to read even a single dirent,
+                // reset the fd and return _EINVAL.
+                fd_seekdir(fd, ptr);
+                return _EINVAL;
+            }
             break;
+        }
         if (user_write(dirents, dirent_data, reclen))
             return _EFAULT;
         dirents += reclen;


### PR DESCRIPTION
If the caller's buffer cannot hold even the first entry, the loop just breaks and `sys_getdents_common` returns 0. Every caller reads 0 as end of directory, so a `readdir()` with a small buffer quietly reports the directory as **empty** rather than failing.

Linux returns `EINVAL` for this case. This rewinds to the entry that did not fit and returns that instead. Only the first iteration can be affected — once something has been written, returning a short count is correct, so the existing behavior for partial fills is unchanged.

### Testing

Repro: `getdents64` on `/` with an 8-byte buffer.

| | result |
|---|---|
| Linux (x86 Ubuntu) | `-1 (Invalid argument)` |
| master | `0` — reads as an empty directory |
| this branch | `-1 (Invalid argument)` |

Also ran a shell smoke test over an Alpine rootfs (`ls`, `find`, directory walks with normal-sized buffers, `/proc` reads, fork/exec churn, redirects, pipes) with no change in behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)