### PR TITLE
Implement FUTEX_WAIT_BITSET and FUTEX_WAKE_BITSET

### DIFF
--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -3,8 +3,15 @@
 #define FUTEX_WAIT_ 0
 #define FUTEX_WAKE_ 1
 #define FUTEX_REQUEUE_ 3
+#define FUTEX_WAIT_BITSET_ 9
+#define FUTEX_WAKE_BITSET_ 10
 #define FUTEX_PRIVATE_FLAG_ 128
-#define FUTEX_CMD_MASK_ ~(FUTEX_PRIVATE_FLAG_)
+#define FUTEX_CLOCK_REALTIME_ 256
+// FUTEX_CLOCK_REALTIME selects the clock for FUTEX_WAIT_BITSET's absolute
+// timeout; like FUTEX_PRIVATE_FLAG it is a modifier, not part of the command,
+// so it has to come off before the switch.
+#define FUTEX_CMD_MASK_ ~(FUTEX_PRIVATE_FLAG_ | FUTEX_CLOCK_REALTIME_)
+#define FUTEX_BITSET_MATCH_ANY_ 0xffffffff
 
 struct futex {
     atomic_uint refcount;
@@ -18,6 +25,7 @@ struct futex_wait {
     cond_t cond;
     struct futex *futex; // will be changed by a requeue
     struct list queue;
+    dword_t bitset; // FUTEX_BITSET_MATCH_ANY_ for a plain FUTEX_WAIT
 };
 
 #define FUTEX_HASH_BITS 12
@@ -90,7 +98,7 @@ static int futex_load(struct futex *futex, dword_t *out) {
     return 0;
 }
 
-static int futex_wait(addr_t uaddr, dword_t val, struct timespec *timeout) {
+static int futex_wait(addr_t uaddr, dword_t val, struct timespec *timeout, dword_t bitset) {
     struct futex *futex = futex_get(uaddr);
     int err = 0;
     dword_t tmp;
@@ -102,6 +110,7 @@ static int futex_wait(addr_t uaddr, dword_t val, struct timespec *timeout) {
         struct futex_wait wait;
         wait.cond = COND_INITIALIZER;
         wait.futex = futex;
+        wait.bitset = bitset;
         list_add_tail(&futex->queue, &wait.queue);
         err = wait_for(&wait.cond, &futex_lock, timeout);
         futex = wait.futex;
@@ -112,7 +121,7 @@ static int futex_wait(addr_t uaddr, dword_t val, struct timespec *timeout) {
     return err;
 }
 
-static int futex_wakelike(int op, addr_t uaddr, dword_t wake_max, dword_t requeue_max, addr_t requeue_addr) {
+static int futex_wakelike(int op, addr_t uaddr, dword_t wake_max, dword_t requeue_max, addr_t requeue_addr, dword_t bitset) {
     struct futex *futex = futex_get(uaddr);
 
     struct futex_wait *wait, *tmp;
@@ -120,6 +129,11 @@ static int futex_wakelike(int op, addr_t uaddr, dword_t wake_max, dword_t requeu
     list_for_each_entry_safe(&futex->queue, wait, tmp, queue) {
         if (woken >= wake_max)
             break;
+        // A waiter only wakes if its mask overlaps the waker's. Plain
+        // FUTEX_WAIT/FUTEX_WAKE both use FUTEX_BITSET_MATCH_ANY_, so they are
+        // unaffected.
+        if ((wait->bitset & bitset) == 0)
+            continue;
         notify(&wait->cond);
         list_remove(&wait->queue);
         woken++;
@@ -149,7 +163,7 @@ static int futex_wakelike(int op, addr_t uaddr, dword_t wake_max, dword_t requeu
 }
 
 int futex_wake(addr_t uaddr, dword_t wake_max) {
-    return futex_wakelike(FUTEX_WAKE_, uaddr, wake_max, 0, 0);
+    return futex_wakelike(FUTEX_WAKE_, uaddr, wake_max, 0, 0, FUTEX_BITSET_MATCH_ANY_);
 }
 
 dword_t sys_futex(addr_t uaddr, dword_t op, dword_t val, addr_t timeout_or_val2, addr_t uaddr2, dword_t val3) {
@@ -157,23 +171,49 @@ dword_t sys_futex(addr_t uaddr, dword_t op, dword_t val, addr_t timeout_or_val2,
         STRACE("!FUTEX_PRIVATE ");
     }
     struct timespec timeout = {0};
-    if ((op & FUTEX_CMD_MASK_) == FUTEX_WAIT_ && timeout_or_val2) {
+    int cmd = op & FUTEX_CMD_MASK_;
+    if ((cmd == FUTEX_WAIT_ || cmd == FUTEX_WAIT_BITSET_) && timeout_or_val2) {
         struct timespec_ timeout_;
         if (user_get(timeout_or_val2, timeout_))
             return _EFAULT;
         timeout.tv_sec = timeout_.sec;
         timeout.tv_nsec = timeout_.nsec;
+        if (cmd == FUTEX_WAIT_BITSET_) {
+            // FUTEX_WAIT takes a relative timeout, FUTEX_WAIT_BITSET an
+            // absolute one -- against CLOCK_REALTIME when FUTEX_CLOCK_REALTIME
+            // is set, CLOCK_MONOTONIC otherwise. wait_for wants it relative.
+            struct timespec now;
+            clock_gettime(op & FUTEX_CLOCK_REALTIME_ ? CLOCK_REALTIME : CLOCK_MONOTONIC, &now);
+            timeout.tv_sec -= now.tv_sec;
+            timeout.tv_nsec -= now.tv_nsec;
+            if (timeout.tv_nsec < 0) {
+                timeout.tv_nsec += 1000000000;
+                timeout.tv_sec--;
+            }
+            if (timeout.tv_sec < 0)
+                timeout.tv_sec = timeout.tv_nsec = 0; // already expired
+        }
     }
-    switch (op & FUTEX_CMD_MASK_) {
+    switch (cmd) {
         case FUTEX_WAIT_:
             STRACE("futex(FUTEX_WAIT, %#x, %d, 0x%x {%ds %dns}) = ...\n", uaddr, val, timeout_or_val2, timeout.tv_sec, timeout.tv_nsec);
-            return futex_wait(uaddr, val, timeout_or_val2 ? &timeout : NULL);
+            return futex_wait(uaddr, val, timeout_or_val2 ? &timeout : NULL, FUTEX_BITSET_MATCH_ANY_);
+        case FUTEX_WAIT_BITSET_:
+            STRACE("futex(FUTEX_WAIT_BITSET, %#x, %d, 0x%x {%ds %dns}, %#x) = ...\n", uaddr, val, timeout_or_val2, timeout.tv_sec, timeout.tv_nsec, val3);
+            if (val3 == 0)
+                return _EINVAL;
+            return futex_wait(uaddr, val, timeout_or_val2 ? &timeout : NULL, val3);
         case FUTEX_WAKE_:
             STRACE("futex(FUTEX_WAKE, %#x, %d)", uaddr, val);
-            return futex_wakelike(op & FUTEX_CMD_MASK_, uaddr, val, 0, 0);
+            return futex_wakelike(cmd, uaddr, val, 0, 0, FUTEX_BITSET_MATCH_ANY_);
+        case FUTEX_WAKE_BITSET_:
+            STRACE("futex(FUTEX_WAKE_BITSET, %#x, %d, %#x)", uaddr, val, val3);
+            if (val3 == 0)
+                return _EINVAL;
+            return futex_wakelike(FUTEX_WAKE_, uaddr, val, 0, 0, val3);
         case FUTEX_REQUEUE_:
             STRACE("futex(FUTEX_REQUEUE, %#x, %d, %#x)", uaddr, val, uaddr2);
-            return futex_wakelike(op & FUTEX_CMD_MASK_, uaddr, val, timeout_or_val2, uaddr2);
+            return futex_wakelike(cmd, uaddr, val, timeout_or_val2, uaddr2, FUTEX_BITSET_MATCH_ANY_);
     }
     STRACE("futex(%#x, %d, %d, timeout=%#x, %#x, %d) ", uaddr, op, val, timeout_or_val2, uaddr2, val3);
     FIXME("unsupported futex operation %d", op);


### PR DESCRIPTION
Any program that uses a pthread barrier or an absolute condition-variable timeout dies on master with:

```
The futex facility returned an unexpected error code.
```

glibc's `pthread_cond_timedwait` and `pthread_barrier_wait` issue **`FUTEX_WAIT_BITSET | FUTEX_CLOCK_REALTIME`**, which is op **265**. `sys_futex` only strips `FUTEX_PRIVATE_FLAG` before its switch, so the clock bit survives, nothing matches, and the call falls through to `ENOSYS` — which glibc treats as fatal and aborts on.

I found this while trying to write a threaded stress test against master for an unrelated PR, and it turned out to be blocking any threaded test at all.

### The change

Three parts, all in `kernel/futex.c`:

- **`FUTEX_CLOCK_REALTIME` joins `FUTEX_CMD_MASK_`.** Like `FUTEX_PRIVATE_FLAG` it is a modifier on the command, not part of it.
- **`FUTEX_WAIT_BITSET`/`FUTEX_WAKE_BITSET` carry a mask.** A waiter records the mask it waited with and only wakes if it overlaps the waker's. Plain `FUTEX_WAIT`/`FUTEX_WAKE` pass `FUTEX_BITSET_MATCH_ANY`, so their behaviour is unchanged. A zero mask is `EINVAL`, as on Linux.
- **Timeout base differs.** `FUTEX_WAIT`'s timeout is relative; `FUTEX_WAIT_BITSET`'s is absolute, against `CLOCK_REALTIME` when the flag is set and `CLOCK_MONOTONIC` otherwise. It is converted before being handed to `wait_for`, and an already-expired deadline becomes a zero timeout rather than a negative one.

### Testing

Same static i386 binary on real Linux (x86 Ubuntu) and on iSH:

| | before | after | real Linux |
|---|---|---|---|
| `pthread_barrier_wait` | aborts, 3/3 runs | completes | completes |
| `pthread_cond_timedwait` that times out | aborts | `ETIMEDOUT` after **0.304s** | `ETIMEDOUT` after **0.303s** |
| `pthread_cond_timedwait` that gets signalled | aborts | wakes on the signal, not the deadline | same |
| plain `pthread_cond_wait` | works | works | works |

The last row is the regression check on the untouched `FUTEX_WAIT` path, and the timing rows check the absolute→relative conversion in both directions — a sign error there would show up as an immediate return or a hang rather than a wrong answer.

Also re-ran the pty, SIGURG, `fstatat` and threaded COW-fault tests I had to hand, plus an Alpine shell smoke with background jobs: unchanged.

### Not included

The other unimplemented ops (`FUTEX_CMP_REQUEUE`, `FUTEX_WAKE_OP`, the PI family) are left alone. They are separate work and nothing I ran needed them; this is deliberately scoped to the one that makes glibc abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)