### PR TITLE
Implement fninit

### DIFF
--- a/asbestos/gen.c
+++ b/asbestos/gen.c
@@ -412,6 +412,7 @@ void helper_rdtsc(struct cpu_state *cpu);
 #define FLDENV(val,z) h_write(fpu_ldenv, z)
 #define FSAVE(val,z) h_write(fpu_save, z)
 #define FRESTORE(val,z) h_write(fpu_restore, z)
+#define FINIT() h(fpu_init)
 #define FCLEX() h(fpu_clex)
 #define FPOP h(fpu_pop)
 #define FINCSTP() h(fpu_incstp)

--- a/emu/decode.h
+++ b/emu/decode.h
@@ -1084,6 +1084,7 @@ restart:
                     case 0xd976: TRACE("fsin"); FSIN(); break;
                     case 0xd977: TRACE("fcos"); FCOS(); break;
                     case 0xdb42: TRACE("fnclex"); FCLEX(); break;
+                    case 0xdb43: TRACE("fninit"); FINIT(); break;
                     case 0xde31: TRACE("fcompp"); FCOM(); FPOP; FPOP; break;
                     case 0xdf40: TRACE("fnstsw ax"); FSTSW(reg_a); break;
                     default: TRACE("undefined"); UNDEFINED;

--- a/emu/fpu.c
+++ b/emu/fpu.c
@@ -377,6 +377,18 @@ void fpu_restore32(struct cpu_state *cpu, struct fpu_state32 *state) {
         memcpy(&ST(i), state->regs[i], 10);
 }
 
+// FNINIT: control word back to 0x037f (all exceptions masked, round to
+// nearest, extended precision) and the status word cleared. Clearing fsw also
+// resets TOP, since TOP is a field of it, which is what empties the register
+// stack; there is no tag word to write because we do not model one. The
+// control word changing means the live rounding mode has to follow it, the
+// same way fldcw does.
+void fpu_init(struct cpu_state *cpu) {
+    cpu->fcw = 0x037f;
+    cpu->fsw = 0;
+    f80_rounding_mode = cpu->rc;
+}
+
 void fpu_clex(struct cpu_state *cpu) {
     cpu->pe = cpu->ue = cpu->oe = cpu->ze = cpu->de = cpu->ie = cpu->es = cpu->sf = cpu->b = 0;
 }

--- a/emu/fpu.h
+++ b/emu/fpu.h
@@ -119,6 +119,7 @@ void fpu_stenv32(struct cpu_state *cpu, struct fpu_env32 *env);
 void fpu_ldenv32(struct cpu_state *cpu, struct fpu_env32 *env);
 void fpu_save32(struct cpu_state *cpu, struct fpu_state32 *state);
 void fpu_restore32(struct cpu_state *cpu, struct fpu_state32 *state);
+void fpu_init(struct cpu_state *cpu);
 void fpu_clex(struct cpu_state *cpu);
 
 #endif


### PR DESCRIPTION
`fninit` (DB E3) is missing from the x87 decode table, so it raises SIGILL, while its immediate neighbour `fnclex` (DB E2) is there.

Reported in #2415, where it kills the Free Pascal compiler at startup: fpc emits `fninit` in its FPU setup, so nothing compiled with it runs.

### What it does

Resets the control word to `0x037f` and clears the status word. Clearing `fsw` also resets TOP, since TOP is a field of it, which is what empties the register stack; there is no tag word to write because none is modelled. The control word changing means the live rounding mode has to follow it, the same way `fldcw` does.

### Verification

Same static i386 binary run on real Linux and on iSH, after dirtying the FPU with a non-default control word and a non-empty register stack:

| | before | after / real Linux |
|---|---|---|
| `fninit` | SIGILL | runs |
| control word | -- | `0x037f` |
| status word (incl. TOP) | -- | `0x0000` |
| FPU usable afterwards | -- | yes |

Reproduced on the Alpine 3.19.0 rootfs the App Store build downloads (`ROOTFS_URL` in `app/iSH.xcconfig`), against master 7864dd60.

Note that `fpc` is not packaged for x86 in 3.19, so this is the instruction on its own rather than that program; #2415 is the report, the table above is the check.

The test reads the status word with `fnstsw ax` rather than `fnstsw m16`, because the memory form is also unimplemented. That is a separate gap.
