### PR TITLE
time: unlock pids_lock before returning from timer_create

### DIFF
--- a/kernel/time.c
+++ b/kernel/time.c
@@ -274,8 +274,10 @@ int_t sys_timer_create(dword_t clock, addr_t sigevent_addr, addr_t timer_addr) {
 
     if (sigev.method == SIGEV_THREAD_ID_) {
         lock(&pids_lock);
-        if (pid_get_task(sigev.tid) == NULL)
+        if (pid_get_task(sigev.tid) == NULL) {
+            unlock(&pids_lock);
             return _EINVAL;
+        }
         unlock(&pids_lock);
     }
 


### PR DESCRIPTION
When timer_create() is called with SIGEV_THREAD_ID and the specified TID does not exist, pids_lock is acquired but not released before returning -EINVAL.

Release pids_lock on this error path to avoid leaving the lock held after timer_create() returns.