### PR TITLE
Add option to keep keyboard hidden in mouse mode

### DIFF
--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -18,6 +18,7 @@
 @property (weak, nonatomic) IBOutlet UITableViewCell *capsLockMappingCell;
 @property (weak, nonatomic) IBOutlet UITableViewCell *themeCell;
 @property (weak, nonatomic) IBOutlet UISwitch *disableDimmingSwitch;
+@property (weak, nonatomic) IBOutlet UISwitch *keepKeyboardHiddenInMouseModeSwitch;
 @property (weak, nonatomic) IBOutlet UITextField *launchCommandField;
 @property (weak, nonatomic) IBOutlet UITextField *bootCommandField;
 
@@ -56,7 +57,7 @@
                           [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
                           [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"]];
 
-    [UserPreferences.shared observe:@[@"capsLockMapping", @"fontSize", @"launchCommand", @"bootCommand"]
+    [UserPreferences.shared observe:@[@"capsLockMapping", @"fontSize", @"keepKeyboardHiddenInMouseMode", @"launchCommand", @"bootCommand"]
                             options:0 owner:self usingBlock:^(typeof(self) self) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [self _updateUI];
@@ -91,6 +92,7 @@
 - (void)_updateUI {
     NSAssert(NSThread.isMainThread, @"This method needs to be called on the main thread");
     self.disableDimmingSwitch.on = UserPreferences.shared.shouldDisableDimming;
+    self.keepKeyboardHiddenInMouseModeSwitch.on = UserPreferences.shared.keepKeyboardHiddenInMouseMode;
     self.launchCommandField.text = [UserPreferences.shared.launchCommand componentsJoinedByString:@" "];
     self.bootCommandField.text = [UserPreferences.shared.bootCommand componentsJoinedByString:@" "];
 
@@ -148,6 +150,10 @@
 
 - (IBAction)disableDimmingChanged:(id)sender {
     UserPreferences.shared.shouldDisableDimming = self.disableDimmingSwitch.on;
+}
+
+- (IBAction)keepKeyboardHiddenInMouseModeChanged:(id)sender {
+    UserPreferences.shared.keepKeyboardHiddenInMouseMode = self.keepKeyboardHiddenInMouseModeSwitch.on;
 }
 
 - (IBAction)textBoxSubmit:(id)sender {

--- a/app/Base.lproj/About.storyboard
+++ b/app/Base.lproj/About.storyboard
@@ -270,6 +270,40 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection footerTitle="When enabled, taps sent to terminal apps using mouse input will not show the software keyboard. Two-finger tap the terminal to show it." id="W7R-mk-Kbd">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="XkB-hd-Mse" userLabel="Keep Keyboard Hidden in Mouse Mode">
+                                        <rect key="frame" x="0.0" y="620.5" width="320" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="XkB-hd-Mse" id="Ckb-hd-Mse">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Keep Keyboard Hidden" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lkb-hd-Mse">
+                                                    <rect key="frame" x="16" y="11.5" width="181" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Skb-hd-Mse">
+                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
+                                                    <accessibility key="accessibilityConfiguration" label="Keep Keyboard Hidden in Mouse Mode"/>
+                                                    <connections>
+                                                        <action selector="keepKeyboardHiddenInMouseModeChanged:" destination="yJz-O7-jlW" eventType="valueChanged" id="Akb-hd-Mse"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Skb-hd-Mse" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Lkb-hd-Mse" secondAttribute="trailing" constant="8" symbolic="YES" id="1kb-hd-Mse"/>
+                                                <constraint firstItem="Lkb-hd-Mse" firstAttribute="leading" secondItem="Ckb-hd-Mse" secondAttribute="leadingMargin" id="2kb-hd-Mse"/>
+                                                <constraint firstItem="Skb-hd-Mse" firstAttribute="centerY" secondItem="Ckb-hd-Mse" secondAttribute="centerY" id="3kb-hd-Mse"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Skb-hd-Mse" secondAttribute="trailing" id="4kb-hd-Mse"/>
+                                                <constraint firstItem="Lkb-hd-Mse" firstAttribute="centerY" secondItem="Ckb-hd-Mse" secondAttribute="centerY" id="5kb-hd-Mse"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection headerTitle="Secret Advanced Debugging Options" footerTitle="Warning: Changing these can break everything! If that happens, there's a reset switch in the Settings app." id="d0T-DL-SuP">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="RKb-ed-FOs" userLabel="Init Command">
@@ -391,6 +425,7 @@
                         <outlet property="disableDimmingSwitch" destination="cPj-sQ-qsh" id="Kjp-xA-A0Y"/>
                         <outlet property="exportContainerCell" destination="OIE-9g-Btx" id="qxo-l5-0Mq"/>
                         <outlet property="launchCommandField" destination="gDx-hv-hhV" id="RQn-gk-Dx8"/>
+                        <outlet property="keepKeyboardHiddenInMouseModeSwitch" destination="Skb-hd-Mse" id="Okb-hd-Mse"/>
                         <outlet property="openDiscord" destination="K5r-jy-Dzl" id="b4l-Vr-6l8"/>
                         <outlet property="openFediverse" destination="bge-GA-6p8" id="ghM-X8-itm"/>
                         <outlet property="openGithub" destination="F4i-eC-hQ6" id="66M-sQ-RJR"/>

--- a/app/TerminalView.m
+++ b/app/TerminalView.m
@@ -252,6 +252,12 @@ static NSString *const HANDLERS[] = {@"syncFocus", @"focus", @"newScrollHeight",
     if ([message.name isEqualToString:@"syncFocus"]) {
         self.terminalFocused = self.terminalFocused;
     } else if ([message.name isEqualToString:@"focus"]) {
+        NSDictionary *focusInfo = [message.body isKindOfClass:NSDictionary.class] ? message.body : @{};
+        BOOL force = [focusInfo[@"force"] boolValue];
+        BOOL mouseReporting = [focusInfo[@"mouseReporting"] boolValue];
+        if (!force && mouseReporting && UserPreferences.shared.keepKeyboardHiddenInMouseMode) {
+            return;
+        }
         if (!self.isFirstResponder) {
             [self becomeFirstResponder];
         }

--- a/app/UserPreferences.h
+++ b/app/UserPreferences.h
@@ -55,6 +55,7 @@ extern NSString *const kThemeBackgroundColor;
 @property (nonatomic) Theme *theme;
 @property (nonatomic) Palette *palette;
 @property BOOL shouldDisableDimming;
+@property BOOL keepKeyboardHiddenInMouseMode;
 @property (null_resettable) NSString *fontFamily;
 @property (readonly) NSString *fontFamilyUserFacingName;
 @property (readonly) UIFont *approximateFont;

--- a/app/UserPreferences.m
+++ b/app/UserPreferences.m
@@ -20,6 +20,7 @@ static NSString *const kPreferenceFontFamilyKey = @"Font Family";
 static NSString *const kPreferenceFontSizeKey = @"Font Size";
 static NSString *const kPreferenceThemeKey = @"ModernTheme";
 static NSString *const kPreferenceDisableDimmingKey = @"Disable Dimming";
+static NSString *const kPreferenceKeepKeyboardHiddenInMouseModeKey = @"Keep Keyboard Hidden in Mouse Mode";
 NSString *const kPreferenceLaunchCommandKey = @"Init Command";
 NSString *const kPreferenceBootCommandKey = @"Boot Command";
 static NSString *const kPreferenceCursorStyleKey = @"Cursor Style";
@@ -160,6 +161,7 @@ bool (*remove_user_default)(const char *name);
             kPreferenceHideExtraKeysWithExternalKeyboardKey: @(NO),
             kPreferenceOverrideControlSpaceKey: @(NO),
             kPreferenceDisableDimmingKey: @(NO),
+            kPreferenceKeepKeyboardHiddenInMouseModeKey: @(NO),
             kPreferenceLaunchCommandKey: @[@"/bin/login", @"-f", @"root"],
             kPreferenceBootCommandKey: @[@"/sbin/init"],
             kPreferenceBlinkCursorKey: @(NO),
@@ -194,6 +196,7 @@ bool (*remove_user_default)(const char *name);
             @"font_family": kPreferenceFontFamilyKey,
             @"font_size": kPreferenceFontSizeKey,
             @"disable_dimming": kPreferenceDisableDimmingKey,
+            @"keep_keyboard_hidden_in_mouse_mode": kPreferenceKeepKeyboardHiddenInMouseModeKey,
             @"launch_command": kPreferenceLaunchCommandKey,
             @"boot_command": kPreferenceBootCommandKey,
             @"cursor_style": kPreferenceCursorStyleKey,
@@ -219,6 +222,7 @@ bool (*remove_user_default)(const char *name);
             kPreferenceFontFamilyKey: property(fontFamily),
             kPreferenceFontSizeKey: property(fontSize),
             kPreferenceDisableDimmingKey: property(shouldDisableDimming),
+            kPreferenceKeepKeyboardHiddenInMouseModeKey: property(keepKeyboardHiddenInMouseMode),
             kPreferenceLaunchCommandKey: property(launchCommand),
             kPreferenceBootCommandKey: property(bootCommand),
             kPreferenceCursorStyleKey: property(cursorStyle),
@@ -416,6 +420,19 @@ bool (*remove_user_default)(const char *name);
 }
 
 - (BOOL)validateShouldDisableDimming:(id *)value error:(NSError **)error {
+    return [*value isKindOfClass:NSNumber.class];
+}
+
+// MARK: keepKeyboardHiddenInMouseMode
+- (BOOL)keepKeyboardHiddenInMouseMode {
+    return [_defaults boolForKey:kPreferenceKeepKeyboardHiddenInMouseModeKey];
+}
+
+- (void)setKeepKeyboardHiddenInMouseMode:(BOOL)keepKeyboardHiddenInMouseMode {
+    [_defaults setBool:keepKeyboardHiddenInMouseMode forKey:kPreferenceKeepKeyboardHiddenInMouseModeKey];
+}
+
+- (BOOL)validateKeepKeyboardHiddenInMouseMode:(id *)value error:(NSError **)error {
     return [*value isKindOfClass:NSNumber.class];
 }
 

--- a/app/terminal/term.js
+++ b/app/terminal/term.js
@@ -88,11 +88,20 @@ term.scrollPort_.screen_.addEventListener('blur', (e) => {
         e.stopPropagation();
     }
 }, {capture: true});
+const terminalMouseReporting = () =>
+    term.vt.mouseReport != term.vt.MOUSE_REPORT_DISABLED;
+term.scrollPort_.screen_.addEventListener('touchstart', (e) => {
+    if (terminalMouseReporting() && e.touches.length == 2) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        native.focus({force: true});
+    }
+}, {capture: true, passive: false});
 term.scrollPort_.screen_.addEventListener('mousedown', (e) => {
     // Taps while there is a selection should be left to the selection view
     if ((document.getSelection().rangeCount != 0) &&
         (!document.getSelection().isCollapsed)) return;
-    native.focus();
+    native.focus({mouseReporting: terminalMouseReporting()});
 });
 exports.setFocused = (focus) => {
     if (focus)


### PR DESCRIPTION
## Summary

- add a **Keep Keyboard Hidden** setting for terminal programs using VT mouse reporting
- preserve the current tap-to-focus behavior by leaving the setting off by default
- let a two-finger tap explicitly restore keyboard focus while mouse reporting is active
- expose the preference as `keep_keyboard_hidden_in_mouse_mode` through `/proc/ish/defaults`

## Motivation

Full-screen terminal applications such as Emacs use mouse events for controls. iSH currently asks the native view to become first responder after every terminal tap, so tapping a control immediately reopens a software keyboard that the user deliberately hid. With this option enabled, mouse-aware applications receive the tap without also showing the keyboard.

## Testing

- `node --check app/terminal/term.js`
- unsigned generic iOS build with `Debug-ApplePleaseFixFB19282108`
- signed device build installed over an existing app container
- verified the Settings storyboard compiles and links with the new outlet/action
- manually verified the original behavior before converting it to a persisted toggle: one-finger mouse-mode taps keep the keyboard hidden, two-finger tap restores it, and ordinary terminal taps still focus outside mouse mode